### PR TITLE
Add RSS feeds, accessibility fixes, hreflang tags, and 404 page

### DIFF
--- a/docs/plans/site-improvements.md
+++ b/docs/plans/site-improvements.md
@@ -12,40 +12,10 @@ A prioritised list of improvements identified during a site review. Grouped by i
 - [x] Add Open Graph and Twitter Card meta tags to all pages
 - [x] Add canonical URLs to all pages
 - [x] Remove stale Hugo theme reference from `renovate.json`
-
-## Up Next — High Impact
-
-### RSS Feed (per-language)
-
-The site follows POSSE but has no feed for subscribers.
-
-- Install `@astrojs/rss`
-- Create `src/pages/{en,es,cat}/rss.xml.ts` endpoints
-- Add `<link rel="alternate" type="application/rss+xml">` to `Layout.astro`
-- Add RSS link to footer or connect page
-
-### Accessibility Fixes
-
-Semantic HTML is solid, but WCAG 2.1 AA basics are missing.
-
-- Skip-to-content link (visually hidden, shown on focus)
-- `aria-label` on nav, language switcher
-- `aria-current="page"` on active nav link
-- Escape key handler to close Konami overlay
-- `role="dialog"` + `aria-modal="true"` on Konami overlay
-
-### hreflang Tags
-
-Search engines need these to understand `/en/`, `/es/`, `/cat/` are translations of each other.
-
-- Add `<link rel="alternate" hreflang="...">` for each locale in `Layout.astro`
-- Add `hreflang="x-default"` pointing to English
-
-### Custom 404 Page
-
-Dead links currently show a generic page with no navigation back.
-
-- Create `src/pages/404.astro` with links to all three locales
+- [x] RSS Feed — per-language `rss.xml.ts` endpoints, `<link>` tag in head, RSS link in footer
+- [x] Accessibility — skip-to-content link, `aria-label` on nav & language switcher, `aria-current="page"` on active nav links, Escape key to close Konami overlay, `role="dialog"` + `aria-modal` on Konami overlay
+- [x] hreflang tags — `<link rel="alternate" hreflang="...">` for each locale + `x-default`
+- [x] Custom 404 page — `src/pages/404.astro` with links to all three locales
 
 ## Nice Touches — Lower Priority
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@astrojs/mdx": "^4.3.13",
+        "@astrojs/rss": "^4.0.15",
         "@astrojs/sitemap": "^3.7.0",
         "astro": "^5.16.15"
       }
@@ -91,6 +92,16 @@
       },
       "engines": {
         "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@astrojs/rss": {
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.15.tgz",
+      "integrity": "sha512-uXO/k6AhRkIDXmRoc6xQpoPZrimQNUmS43X4+60yunfuMNHtSRN5e/FiSi7NApcZqmugSMc5+cJi8ovqgO+qIg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "^5.3.3",
+        "piccolore": "^0.1.3"
       }
     },
     "node_modules/@astrojs/sitemap": {
@@ -2602,6 +2613,24 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/fast-xml-parser": {
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.6.tgz",
+      "integrity": "sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.2"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -5097,6 +5126,18 @@
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
+      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/style-to-js": {
       "version": "1.1.21",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@astrojs/mdx": "^4.3.13",
+    "@astrojs/rss": "^4.0.15",
     "@astrojs/sitemap": "^3.7.0",
     "astro": "^5.16.15"
   }

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -14,6 +14,9 @@ export const translations = {
     'nav.writing': 'Writing',
     'nav.connect': 'Connect',
     'nav.fun': 'Arcade',
+    'nav.skipToContent': 'Skip to content',
+    'nav.mainNavigation': 'Main navigation',
+    'nav.languageSwitcher': 'Language switcher',
 
     // Hero
     'hero.greeting': "Hi, I'm",
@@ -91,6 +94,9 @@ export const translations = {
     'nav.writing': 'Escritos',
     'nav.connect': 'Conectar',
     'nav.fun': 'Arcade',
+    'nav.skipToContent': 'Saltar al contenido',
+    'nav.mainNavigation': 'Navegación principal',
+    'nav.languageSwitcher': 'Selector de idioma',
 
     // Hero
     'hero.greeting': 'Hola, soy',
@@ -168,6 +174,9 @@ export const translations = {
     'nav.writing': 'Escrits',
     'nav.connect': 'Connectar',
     'nav.fun': 'Arcade',
+    'nav.skipToContent': 'Saltar al contingut',
+    'nav.mainNavigation': 'Navegació principal',
+    'nav.languageSwitcher': 'Selector d\'idioma',
 
     // Hero
     'hero.greeting': 'Hola, sóc',

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -17,6 +17,8 @@ const t = useTranslations(lang);
 const currentPath = Astro.url.pathname.replace(`/${lang}`, '') || '/';
 const canonicalUrl = customCanonical || new URL(Astro.url.pathname, Astro.site).href;
 const fullTitle = `${title} | Ismael Martinez`;
+const locales = ['en', 'es', 'cat'] as const;
+const hreflangMap: Record<string, string> = { en: 'en', es: 'es', cat: 'ca' };
 ---
 
 <!doctype html>
@@ -44,29 +46,42 @@ const fullTitle = `${title} | Ismael Martinez`;
     <meta name="twitter:title" content={fullTitle} />
     <meta name="twitter:description" content={description} />
 
+    <!-- hreflang alternates -->
+    {locales.map(locale => (
+      <link rel="alternate" hreflang={hreflangMap[locale]} href={new URL(getLocalizedPath(currentPath, locale), Astro.site).href} />
+    ))}
+    <link rel="alternate" hreflang="x-default" href={new URL(getLocalizedPath(currentPath, 'en'), Astro.site).href} />
+
+    <!-- RSS Feed -->
+    <link rel="alternate" type="application/rss+xml" title={`Ismael Martinez (${lang.toUpperCase()})`} href={`/${lang}/rss.xml`} />
+
     <slot name="head" />
 
     <!-- Umami Analytics -->
     <script defer src="https://cloud.umami.is/script.js" data-website-id="d3ef0011-73bb-46a5-a248-f5220efa13eb"></script>
   </head>
   <body>
-    <nav class="nav">
+    <a href="#main-content" class="skip-link">{t('nav.skipToContent')}</a>
+
+    <nav class="nav" aria-label={t('nav.mainNavigation')}>
       <div class="container nav-container">
         <a href={getLocalizedPath('/', lang)} class="nav-logo">IMR</a>
 
         <ul class="nav-links">
-          <li><a href={getLocalizedPath('/', lang)}>{t('nav.home')}</a></li>
-          <li><a href={getLocalizedPath('/projects', lang)}>{t('nav.projects')}</a></li>
-          <li><a href={getLocalizedPath('/writing', lang)}>{t('nav.writing')}</a></li>
-          <li id="arcade-nav" class="arcade-nav-hidden"><a href={getLocalizedPath('/fun', lang)}>{t('nav.fun')}</a></li>
-          <li><a href={getLocalizedPath('/connect', lang)}>{t('nav.connect')}</a></li>
+          <li><a href={getLocalizedPath('/', lang)} aria-current={currentPath === '/' ? 'page' : undefined}>{t('nav.home')}</a></li>
+          <li><a href={getLocalizedPath('/projects', lang)} aria-current={currentPath === '/projects' ? 'page' : undefined}>{t('nav.projects')}</a></li>
+          <li><a href={getLocalizedPath('/writing', lang)} aria-current={currentPath === '/writing' ? 'page' : undefined}>{t('nav.writing')}</a></li>
+          <li id="arcade-nav" class="arcade-nav-hidden"><a href={getLocalizedPath('/fun', lang)} aria-current={currentPath.startsWith('/fun') ? 'page' : undefined}>{t('nav.fun')}</a></li>
+          <li><a href={getLocalizedPath('/connect', lang)} aria-current={currentPath === '/connect' ? 'page' : undefined}>{t('nav.connect')}</a></li>
         </ul>
 
-        <div class="lang-switcher">
+        <div class="lang-switcher" role="navigation" aria-label={t('nav.languageSwitcher')}>
           {Object.entries(languages).map(([code, name]) => (
             <a
               href={getLocalizedPath(currentPath, code)}
               class:list={['lang-link', { active: lang === code }]}
+              aria-current={lang === code ? 'true' : undefined}
+              lang={hreflangMap[code]}
             >
               {code.toUpperCase()}
             </a>
@@ -75,7 +90,7 @@ const fullTitle = `${title} | Ismael Martinez`;
       </div>
     </nav>
 
-    <main>
+    <main id="main-content">
       <slot />
     </main>
 
@@ -84,12 +99,15 @@ const fullTitle = `${title} | Ismael Martinez`;
         <p>
           {t('footer.built')} <a href="https://astro.build" target="_blank" rel="noopener">Astro</a> {t('footer.and')} ☕
         </p>
+        <p class="footer-links">
+          <a href={`/${lang}/rss.xml`} class="footer-rss" aria-label="RSS Feed">RSS</a>
+        </p>
         <p class="footer-copy">&copy; {new Date().getFullYear()} Ismael Martinez</p>
       </div>
     </footer>
 
     <!-- Easter Egg: Konami Code -->
-    <div id="konami-overlay" class="konami-overlay">
+    <div id="konami-overlay" class="konami-overlay" role="dialog" aria-modal="true" aria-label="Secret Arcade Unlocked">
       <div class="konami-content">
         <div class="konami-emoji">🕹️</div>
         <h2>SECRET ARCADE UNLOCKED!</h2>
@@ -114,6 +132,13 @@ const fullTitle = `${title} | Ismael Martinez`;
       let konamiIndex = 0;
 
       document.addEventListener('keydown', (e) => {
+        // Escape key closes Konami overlay
+        if (e.key === 'Escape') {
+          const overlay = document.getElementById('konami-overlay');
+          overlay?.classList.remove('active');
+          return;
+        }
+
         if (e.code === konamiCode[konamiIndex]) {
           konamiIndex++;
           if (konamiIndex === konamiCode.length) {
@@ -176,6 +201,24 @@ const fullTitle = `${title} | Ismael Martinez`;
 </html>
 
 <style>
+  .skip-link {
+    position: absolute;
+    top: -100%;
+    left: var(--space-md);
+    z-index: 200;
+    padding: var(--space-sm) var(--space-md);
+    background: var(--color-accent);
+    color: #fff;
+    border-radius: 0 0 0.25rem 0.25rem;
+    font-weight: 600;
+    text-decoration: none;
+    transition: top 0.2s ease;
+  }
+
+  .skip-link:focus {
+    top: 0;
+  }
+
   .nav {
     position: sticky;
     top: 0;
@@ -210,7 +253,8 @@ const fullTitle = `${title} | Ismael Martinez`;
     transition: color 0.2s ease;
   }
 
-  .nav-links a:hover {
+  .nav-links a:hover,
+  .nav-links a[aria-current="page"] {
     color: var(--color-text);
   }
 
@@ -244,6 +288,21 @@ const fullTitle = `${title} | Ismael Martinez`;
     text-align: center;
     color: var(--color-text-muted);
     font-size: 0.875rem;
+  }
+
+  .footer-links {
+    margin-top: var(--space-sm);
+  }
+
+  .footer-rss {
+    color: var(--color-text-muted);
+    text-decoration: none;
+    font-size: 0.875rem;
+    font-weight: 500;
+  }
+
+  .footer-rss:hover {
+    color: var(--color-accent);
   }
 
   .footer-copy {

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,60 @@
+---
+import '../styles/global.css';
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Page not found" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="robots" content="noindex" />
+    <title>404 — Page Not Found | Ismael Martinez</title>
+  </head>
+  <body>
+    <main class="error-page">
+      <div class="container">
+        <h1 class="error-code">404</h1>
+        <p class="error-message">This page doesn't exist — but these do:</p>
+
+        <nav class="locale-links" aria-label="Choose a language">
+          <a href="/en/" class="btn btn-primary">English</a>
+          <a href="/es/" class="btn btn-outline">Español</a>
+          <a href="/cat/" class="btn btn-outline">Català</a>
+        </nav>
+      </div>
+    </main>
+  </body>
+</html>
+
+<style>
+  .error-page {
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+  }
+
+  .error-code {
+    font-size: 6rem;
+    font-weight: 700;
+    line-height: 1;
+    margin-bottom: var(--space-md);
+    color: var(--color-text-muted);
+  }
+
+  .error-message {
+    font-size: 1.25rem;
+    color: var(--color-text-muted);
+    margin-bottom: var(--space-xl);
+  }
+
+  .locale-links {
+    display: flex;
+    gap: var(--space-md);
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+</style>

--- a/src/pages/cat/rss.xml.ts
+++ b/src/pages/cat/rss.xml.ts
@@ -1,0 +1,27 @@
+import rss from '@astrojs/rss';
+import { getCollection } from 'astro:content';
+import type { APIContext } from 'astro';
+
+export async function GET(context: APIContext) {
+  const articles = await getCollection('articles', ({ slug, data }) => {
+    return slug.startsWith('cat/') && !data.draft;
+  });
+
+  const sortedArticles = articles.sort(
+    (a, b) => b.data.publishedDate.valueOf() - a.data.publishedDate.valueOf()
+  );
+
+  return rss({
+    title: 'Ismael Martinez',
+    description: "Enginyer de Software i Entusiasta de l'Open Source — articles sobre desenvolupament de software, arquitectura i tecnologia.",
+    site: context.site!,
+    items: sortedArticles.map((article) => ({
+      title: article.data.title,
+      pubDate: article.data.publishedDate,
+      description: article.data.description,
+      link: `/cat/articles/${article.slug.replace('cat/', '')}/`,
+      categories: article.data.tags,
+    })),
+    customData: '<language>ca</language>',
+  });
+}

--- a/src/pages/en/rss.xml.ts
+++ b/src/pages/en/rss.xml.ts
@@ -1,0 +1,27 @@
+import rss from '@astrojs/rss';
+import { getCollection } from 'astro:content';
+import type { APIContext } from 'astro';
+
+export async function GET(context: APIContext) {
+  const articles = await getCollection('articles', ({ slug, data }) => {
+    return slug.startsWith('en/') && !data.draft;
+  });
+
+  const sortedArticles = articles.sort(
+    (a, b) => b.data.publishedDate.valueOf() - a.data.publishedDate.valueOf()
+  );
+
+  return rss({
+    title: 'Ismael Martinez',
+    description: 'Software Engineer & Open Source Enthusiast — articles on software development, architecture, and technology.',
+    site: context.site!,
+    items: sortedArticles.map((article) => ({
+      title: article.data.title,
+      pubDate: article.data.publishedDate,
+      description: article.data.description,
+      link: `/en/articles/${article.slug.replace('en/', '')}/`,
+      categories: article.data.tags,
+    })),
+    customData: '<language>en</language>',
+  });
+}

--- a/src/pages/es/rss.xml.ts
+++ b/src/pages/es/rss.xml.ts
@@ -1,0 +1,27 @@
+import rss from '@astrojs/rss';
+import { getCollection } from 'astro:content';
+import type { APIContext } from 'astro';
+
+export async function GET(context: APIContext) {
+  const articles = await getCollection('articles', ({ slug, data }) => {
+    return slug.startsWith('es/') && !data.draft;
+  });
+
+  const sortedArticles = articles.sort(
+    (a, b) => b.data.publishedDate.valueOf() - a.data.publishedDate.valueOf()
+  );
+
+  return rss({
+    title: 'Ismael Martinez',
+    description: 'Ingeniero de Software y Entusiasta del Open Source — artículos sobre desarrollo de software, arquitectura y tecnología.',
+    site: context.site!,
+    items: sortedArticles.map((article) => ({
+      title: article.data.title,
+      pubDate: article.data.publishedDate,
+      description: article.data.description,
+      link: `/es/articles/${article.slug.replace('es/', '')}/`,
+      categories: article.data.tags,
+    })),
+    customData: '<language>es</language>',
+  });
+}


### PR DESCRIPTION
Implements the four high-impact improvements from the site plan:

- Per-language RSS feeds (/en/rss.xml, /es/rss.xml, /cat/rss.xml) via @astrojs/rss
- Accessibility: skip-to-content link, aria-label on nav & language switcher,
  aria-current="page" on active nav links, Escape key closes Konami overlay,
  role="dialog" + aria-modal on Konami overlay
- hreflang alternate link tags for all three locales + x-default
- Custom 404 page with links to all three locale homepages

https://claude.ai/code/session_01UHPSaQgLAZ7cW3BtduRFY5