### PR TITLE
Add uses page, dark mode toggle, view transitions & SEO improvements

### DIFF
--- a/docs/plans/site-improvements.md
+++ b/docs/plans/site-improvements.md
@@ -16,29 +16,9 @@ A prioritised list of improvements identified during a site review. Grouped by i
 - [x] Accessibility — skip-to-content link, `aria-label` on nav & language switcher, `aria-current="page"` on active nav links, Escape key to close Konami overlay, `role="dialog"` + `aria-modal` on Konami overlay
 - [x] hreflang tags — `<link rel="alternate" hreflang="...">` for each locale + `x-default`
 - [x] Custom 404 page — `src/pages/404.astro` with links to all three locales
-
-## Nice Touches — Lower Priority
-
-### View Transitions
-
-Astro has built-in support. Near zero-config, adds smooth page navigation.
-
-### Article Reading Time
-
-Utility function dividing word count by 200. Display next to publish date.
-
-### Print Stylesheet
-
-`@media print` block in `global.css` — hide nav/footer, clean typography, show URLs.
-
-### JSON-LD Structured Data
-
-`Person` schema on homepage, `Article` schema on article pages. Helps rich results in search.
-
-### Dark/Light Mode Toggle
-
-Currently system-preference only. Add a manual toggle stored in `localStorage`.
-
-### /uses Page
-
-Tools, hardware, software stack. Common on developer sites, good for SEO.
+- [x] View Transitions — Astro `<ViewTransitions />` for smooth page navigation, `astro:after-swap` for state persistence
+- [x] Article Reading Time — `src/utils/reading-time.ts` utility (word count ÷ 200), displayed next to publish date in article header
+- [x] Print Stylesheet — `@media print` block in `global.css` hiding nav/footer, clean typography, showing URLs after links
+- [x] JSON-LD Structured Data — `Person` schema on all homepage locales, `Article` schema on article pages
+- [x] Dark/Light Mode Toggle — manual toggle button in nav with `localStorage` persistence, `data-theme` attribute, FOUC prevention script
+- [x] /uses Page — tech stack showcase at `/en/uses`, `/es/uses`, `/cat/uses` with categorised tools, hardware, and software

--- a/src/data/uses.ts
+++ b/src/data/uses.ts
@@ -1,0 +1,192 @@
+interface UsesItem {
+  name: string;
+  description: Record<'en' | 'es' | 'cat', string>;
+  url?: string;
+}
+
+interface UsesCategory {
+  title: Record<'en' | 'es' | 'cat', string>;
+  items: UsesItem[];
+}
+
+export const usesData: UsesCategory[] = [
+  {
+    title: {
+      en: 'Editor & Terminal',
+      es: 'Editor y Terminal',
+      cat: 'Editor i Terminal',
+    },
+    items: [
+      {
+        name: 'VS Code',
+        description: {
+          en: 'My primary code editor with vim keybindings',
+          es: 'Mi editor de código principal con atajos vim',
+          cat: 'El meu editor de codi principal amb dreceres vim',
+        },
+        url: 'https://code.visualstudio.com',
+      },
+      {
+        name: 'Warp',
+        description: {
+          en: 'Modern terminal with AI-powered features',
+          es: 'Terminal moderna con funciones potenciadas por IA',
+          cat: 'Terminal moderna amb funcions potenciades per IA',
+        },
+        url: 'https://www.warp.dev',
+      },
+      {
+        name: 'GitHub Copilot',
+        description: {
+          en: 'AI pair programmer for code suggestions',
+          es: 'Programador en pareja IA para sugerencias de código',
+          cat: 'Programador en parella IA per a suggeriments de codi',
+        },
+        url: 'https://github.com/features/copilot',
+      },
+    ],
+  },
+  {
+    title: {
+      en: 'Languages & Frameworks',
+      es: 'Lenguajes y Frameworks',
+      cat: 'Llenguatges i Frameworks',
+    },
+    items: [
+      {
+        name: 'TypeScript',
+        description: {
+          en: 'My go-to language for most projects',
+          es: 'Mi lenguaje preferido para la mayoría de proyectos',
+          cat: 'El meu llenguatge preferit per a la majoria de projectes',
+        },
+        url: 'https://www.typescriptlang.org',
+      },
+      {
+        name: 'Python',
+        description: {
+          en: 'For data tooling, scripting, and open source projects',
+          es: 'Para herramientas de datos, scripting y proyectos open source',
+          cat: 'Per a eines de dades, scripting i projectes open source',
+        },
+        url: 'https://www.python.org',
+      },
+      {
+        name: 'Astro',
+        description: {
+          en: 'Static site framework powering this very site',
+          es: 'Framework de sitios estáticos que impulsa este sitio',
+          cat: 'Framework de llocs estàtics que impulsa aquest lloc',
+        },
+        url: 'https://astro.build',
+      },
+      {
+        name: 'Node.js',
+        description: {
+          en: 'Runtime for backend services and tooling',
+          es: 'Runtime para servicios backend y herramientas',
+          cat: 'Runtime per a serveis backend i eines',
+        },
+        url: 'https://nodejs.org',
+      },
+    ],
+  },
+  {
+    title: {
+      en: 'DevOps & Infrastructure',
+      es: 'DevOps e Infraestructura',
+      cat: 'DevOps i Infraestructura',
+    },
+    items: [
+      {
+        name: 'Docker',
+        description: {
+          en: 'Containerisation for reproducible environments',
+          es: 'Contenedorización para entornos reproducibles',
+          cat: 'Contenidorització per a entorns reproduïbles',
+        },
+        url: 'https://www.docker.com',
+      },
+      {
+        name: 'GitHub Actions',
+        description: {
+          en: 'CI/CD pipelines for automated builds and deployments',
+          es: 'Pipelines CI/CD para compilaciones y despliegues automatizados',
+          cat: 'Pipelines CI/CD per a compilacions i desplegaments automatitzats',
+        },
+        url: 'https://github.com/features/actions',
+      },
+      {
+        name: 'AWS',
+        description: {
+          en: 'Cloud platform for production workloads',
+          es: 'Plataforma cloud para cargas de trabajo en producción',
+          cat: 'Plataforma cloud per a càrregues de treball en producció',
+        },
+        url: 'https://aws.amazon.com',
+      },
+    ],
+  },
+  {
+    title: {
+      en: 'Productivity',
+      es: 'Productividad',
+      cat: 'Productivitat',
+    },
+    items: [
+      {
+        name: 'Obsidian',
+        description: {
+          en: 'Markdown-based knowledge management and note-taking',
+          es: 'Gestión del conocimiento y notas basada en Markdown',
+          cat: 'Gestió del coneixement i notes basada en Markdown',
+        },
+        url: 'https://obsidian.md',
+      },
+      {
+        name: 'Raycast',
+        description: {
+          en: 'Launcher and productivity tool for macOS',
+          es: 'Lanzador y herramienta de productividad para macOS',
+          cat: 'Llançador i eina de productivitat per a macOS',
+        },
+        url: 'https://www.raycast.com',
+      },
+      {
+        name: 'Arc Browser',
+        description: {
+          en: 'Modern browser with workspace organisation',
+          es: 'Navegador moderno con organización de espacios de trabajo',
+          cat: 'Navegador modern amb organització d\'espais de treball',
+        },
+        url: 'https://arc.net',
+      },
+    ],
+  },
+  {
+    title: {
+      en: 'Hardware',
+      es: 'Hardware',
+      cat: 'Hardware',
+    },
+    items: [
+      {
+        name: 'MacBook Pro',
+        description: {
+          en: 'Apple Silicon — the daily driver',
+          es: 'Apple Silicon — el equipo de uso diario',
+          cat: 'Apple Silicon — l\'equip d\'ús diari',
+        },
+      },
+      {
+        name: 'Ergodox EZ',
+        description: {
+          en: 'Split mechanical keyboard for ergonomics',
+          es: 'Teclado mecánico dividido para ergonomía',
+          cat: 'Teclat mecànic dividit per a ergonomia',
+        },
+        url: 'https://ergodox-ez.com',
+      },
+    ],
+  },
+];

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -17,6 +17,8 @@ export const translations = {
     'nav.skipToContent': 'Skip to content',
     'nav.mainNavigation': 'Main navigation',
     'nav.languageSwitcher': 'Language switcher',
+    'nav.themeToggle': 'Toggle dark/light mode',
+    'nav.uses': 'Uses',
 
     // Hero
     'hero.greeting': "Hi, I'm",
@@ -52,6 +54,11 @@ export const translations = {
     'article.noArticles': 'No articles yet. Check back soon!',
     'article.localArticles': 'Articles',
     'article.externalPlatforms': 'External Platforms',
+    'article.minRead': 'min read',
+
+    // Uses
+    'uses.title': 'Uses',
+    'uses.description': 'Tools, software, and hardware I use for development and everyday work',
 
     // Fun Section
     'fun.title': 'Fun Stuff',
@@ -97,6 +104,8 @@ export const translations = {
     'nav.skipToContent': 'Saltar al contenido',
     'nav.mainNavigation': 'Navegación principal',
     'nav.languageSwitcher': 'Selector de idioma',
+    'nav.themeToggle': 'Cambiar modo oscuro/claro',
+    'nav.uses': 'Herramientas',
 
     // Hero
     'hero.greeting': 'Hola, soy',
@@ -132,6 +141,11 @@ export const translations = {
     'article.noArticles': 'Aún no hay artículos. ¡Vuelve pronto!',
     'article.localArticles': 'Artículos',
     'article.externalPlatforms': 'Plataformas Externas',
+    'article.minRead': 'min de lectura',
+
+    // Uses
+    'uses.title': 'Herramientas',
+    'uses.description': 'Herramientas, software y hardware que uso para desarrollo y trabajo diario',
 
     // Fun Section
     'fun.title': 'Diversión',
@@ -177,6 +191,8 @@ export const translations = {
     'nav.skipToContent': 'Saltar al contingut',
     'nav.mainNavigation': 'Navegació principal',
     'nav.languageSwitcher': 'Selector d\'idioma',
+    'nav.themeToggle': 'Canviar mode fosc/clar',
+    'nav.uses': 'Eines',
 
     // Hero
     'hero.greeting': 'Hola, sóc',
@@ -212,6 +228,11 @@ export const translations = {
     'article.noArticles': 'Encara no hi ha articles. Torna aviat!',
     'article.localArticles': 'Articles',
     'article.externalPlatforms': 'Plataformes Externes',
+    'article.minRead': 'min de lectura',
+
+    // Uses
+    'uses.title': 'Eines',
+    'uses.description': 'Eines, software i hardware que faig servir per al desenvolupament i treball diari',
 
     // Fun Section
     'fun.title': 'Diversió',

--- a/src/layouts/ArticleLayout.astro
+++ b/src/layouts/ArticleLayout.astro
@@ -64,7 +64,7 @@ const articleJsonLd = {
 ---
 
 <Layout title={title} description={description} lang={lang} ogType="article" publishedDate={publishedDate} tags={tags} canonical={originalUrl}>
-  <script slot="head" type="application/ld+json" set:html={JSON.stringify(articleJsonLd)} />
+  <script slot="head" type="application/ld+json" set:html={JSON.stringify(articleJsonLd).replace(/</g, '\\u003c')} />
 
   <article class="article">
     <div class="container">

--- a/src/layouts/ArticleLayout.astro
+++ b/src/layouts/ArticleLayout.astro
@@ -13,9 +13,10 @@ interface Props {
   tags: string[];
   lang: 'en' | 'es' | 'cat';
   slug: string;
+  readingTime?: number;
 }
 
-const { title, description, publishedDate, updatedDate, originalUrl, originalPlatform, tags, lang, slug } = Astro.props;
+const { title, description, publishedDate, updatedDate, originalUrl, originalPlatform, tags, lang, slug, readingTime } = Astro.props;
 const t = useTranslations(lang);
 
 // Get available translations for this article
@@ -37,9 +38,33 @@ const platformLabels = {
   devto: 'Dev.to',
   self: t('article.originallyPublished')
 };
+
+const articleJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": title,
+  "description": description,
+  "datePublished": publishedDate.toISOString(),
+  ...(updatedDate && { "dateModified": updatedDate.toISOString() }),
+  "author": {
+    "@type": "Person",
+    "name": "Ismael Martinez",
+    "url": "https://ismaelmartinez.me.uk"
+  },
+  "publisher": {
+    "@type": "Person",
+    "name": "Ismael Martinez"
+  },
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": `https://ismaelmartinez.me.uk/${lang}/articles/${slug.split('/')[1]}`
+  },
+  ...(tags.length > 0 && { "keywords": tags.join(', ') })
+};
 ---
 
 <Layout title={title} description={description} lang={lang} ogType="article" publishedDate={publishedDate} tags={tags} canonical={originalUrl}>
+  <script slot="head" type="application/ld+json" set:html={JSON.stringify(articleJsonLd)} />
 
   <article class="article">
     <div class="container">
@@ -50,6 +75,9 @@ const platformLabels = {
             <span class="updated">
               · {t('article.updated')} {formatDate(updatedDate)}
             </span>
+          )}
+          {readingTime && (
+            <span class="reading-time">· {readingTime} {t('article.minRead')}</span>
           )}
         </div>
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,4 +1,5 @@
 ---
+import { ViewTransitions } from 'astro:transitions';
 import { languages, useTranslations, getLocalizedPath } from '../i18n/translations';
 import '../styles/global.css';
 
@@ -57,6 +58,16 @@ const hreflangMap: Record<string, string> = { en: 'en', es: 'es', cat: 'ca' };
 
     <slot name="head" />
 
+    <!-- Theme: prevent FOUC -->
+    <script is:inline>
+      (function() {
+        const theme = localStorage.getItem('theme');
+        if (theme) document.documentElement.setAttribute('data-theme', theme);
+      })();
+    </script>
+
+    <ViewTransitions />
+
     <!-- Umami Analytics -->
     <script defer src="https://cloud.umami.is/script.js" data-website-id="d3ef0011-73bb-46a5-a248-f5220efa13eb"></script>
   </head>
@@ -75,17 +86,23 @@ const hreflangMap: Record<string, string> = { en: 'en', es: 'es', cat: 'ca' };
           <li><a href={getLocalizedPath('/connect', lang)} aria-current={currentPath === '/connect' ? 'page' : undefined}>{t('nav.connect')}</a></li>
         </ul>
 
-        <div class="lang-switcher" role="navigation" aria-label={t('nav.languageSwitcher')}>
-          {Object.entries(languages).map(([code, name]) => (
-            <a
-              href={getLocalizedPath(currentPath, code)}
-              class:list={['lang-link', { active: lang === code }]}
-              aria-current={lang === code ? 'true' : undefined}
-              lang={hreflangMap[code]}
-            >
-              {code.toUpperCase()}
-            </a>
-          ))}
+        <div class="nav-actions">
+          <div class="lang-switcher" role="navigation" aria-label={t('nav.languageSwitcher')}>
+            {Object.entries(languages).map(([code, name]) => (
+              <a
+                href={getLocalizedPath(currentPath, code)}
+                class:list={['lang-link', { active: lang === code }]}
+                aria-current={lang === code ? 'true' : undefined}
+                lang={hreflangMap[code]}
+              >
+                {code.toUpperCase()}
+              </a>
+            ))}
+          </div>
+          <button id="theme-toggle" class="theme-toggle" aria-label={t('nav.themeToggle')} type="button">
+            <span class="theme-icon-light">&#9788;</span>
+            <span class="theme-icon-dark">&#9790;</span>
+          </button>
         </div>
       </div>
     </nav>
@@ -100,6 +117,8 @@ const hreflangMap: Record<string, string> = { en: 'en', es: 'es', cat: 'ca' };
           {t('footer.built')} <a href="https://astro.build" target="_blank" rel="noopener">Astro</a> {t('footer.and')} ☕
         </p>
         <p class="footer-links">
+          <a href={getLocalizedPath('/uses', lang)} class="footer-link">{t('nav.uses')}</a>
+          <span class="footer-separator">·</span>
           <a href={`/${lang}/rss.xml`} class="footer-rss" aria-label="RSS Feed">RSS</a>
         </p>
         <p class="footer-copy">&copy; {new Date().getFullYear()} Ismael Martinez</p>
@@ -126,6 +145,9 @@ const hreflangMap: Record<string, string> = { en: 'en', es: 'es', cat: 'ca' };
         }
       }
       checkArcadeUnlocked();
+
+      // Re-check after View Transitions navigation
+      document.addEventListener('astro:after-swap', checkArcadeUnlocked);
 
       // Konami Code: ↑ ↑ ↓ ↓ ← → ← → B A
       const konamiCode = ['ArrowUp', 'ArrowUp', 'ArrowDown', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'ArrowLeft', 'ArrowRight', 'KeyB', 'KeyA'];
@@ -196,6 +218,34 @@ const hreflangMap: Record<string, string> = { en: 'en', es: 'es', cat: 'ca' };
           logoClicks = 0;
         }
       });
+
+      // Theme toggle
+      function initThemeToggle() {
+        const toggle = document.getElementById('theme-toggle');
+        if (!toggle) return;
+
+        toggle.addEventListener('click', () => {
+          const current = document.documentElement.getAttribute('data-theme');
+          let next: string;
+          if (current) {
+            // If manual override is set, toggle it
+            next = current === 'dark' ? 'light' : 'dark';
+          } else {
+            // No manual override — detect system preference and go opposite
+            const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+            next = prefersDark ? 'light' : 'dark';
+          }
+          document.documentElement.setAttribute('data-theme', next);
+          localStorage.setItem('theme', next);
+        });
+      }
+      initThemeToggle();
+
+      document.addEventListener('astro:after-swap', () => {
+        const theme = localStorage.getItem('theme');
+        if (theme) document.documentElement.setAttribute('data-theme', theme);
+        initThemeToggle();
+      });
     </script>
   </body>
 </html>
@@ -262,9 +312,46 @@ const hreflangMap: Record<string, string> = { en: 'en', es: 'es', cat: 'ca' };
     display: none;
   }
 
+  .nav-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-md);
+  }
+
   .lang-switcher {
     display: flex;
     gap: var(--space-sm);
+  }
+
+  .theme-toggle {
+    background: none;
+    border: 1px solid var(--color-border);
+    border-radius: 0.25rem;
+    cursor: pointer;
+    padding: var(--space-xs) var(--space-sm);
+    color: var(--color-text-muted);
+    font-size: 1rem;
+    line-height: 1;
+    transition: all 0.2s ease;
+    display: flex;
+    align-items: center;
+  }
+
+  .theme-toggle:hover {
+    color: var(--color-accent);
+    border-color: var(--color-accent);
+  }
+
+  /* Show sun in dark mode, moon in light mode */
+  .theme-icon-light { display: none; }
+  .theme-icon-dark { display: inline; }
+
+  :global(:root[data-theme="light"]) .theme-icon-light { display: inline; }
+  :global(:root[data-theme="light"]) .theme-icon-dark { display: none; }
+
+  @media (prefers-color-scheme: light) {
+    :global(:root:not([data-theme="dark"])) .theme-icon-light { display: inline; }
+    :global(:root:not([data-theme="dark"])) .theme-icon-dark { display: none; }
   }
 
   .lang-link {
@@ -294,6 +381,7 @@ const hreflangMap: Record<string, string> = { en: 'en', es: 'es', cat: 'ca' };
     margin-top: var(--space-sm);
   }
 
+  .footer-link,
   .footer-rss {
     color: var(--color-text-muted);
     text-decoration: none;
@@ -301,8 +389,14 @@ const hreflangMap: Record<string, string> = { en: 'en', es: 'es', cat: 'ca' };
     font-weight: 500;
   }
 
+  .footer-link:hover,
   .footer-rss:hover {
     color: var(--color-accent);
+  }
+
+  .footer-separator {
+    color: var(--color-text-muted);
+    margin: 0 var(--space-xs);
   }
 
   .footer-copy {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -146,8 +146,7 @@ const hreflangMap: Record<string, string> = { en: 'en', es: 'es', cat: 'ca' };
       }
       checkArcadeUnlocked();
 
-      // Re-check after View Transitions navigation
-      document.addEventListener('astro:after-swap', checkArcadeUnlocked);
+
 
       // Konami Code: ↑ ↑ ↓ ↓ ← → ← → B A
       const konamiCode = ['ArrowUp', 'ArrowUp', 'ArrowDown', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'ArrowLeft', 'ArrowRight', 'KeyB', 'KeyA'];
@@ -245,6 +244,7 @@ const hreflangMap: Record<string, string> = { en: 'en', es: 'es', cat: 'ca' };
         const theme = localStorage.getItem('theme');
         if (theme) document.documentElement.setAttribute('data-theme', theme);
         initThemeToggle();
+        checkArcadeUnlocked();
       });
     </script>
   </body>
@@ -342,7 +342,7 @@ const hreflangMap: Record<string, string> = { en: 'en', es: 'es', cat: 'ca' };
     border-color: var(--color-accent);
   }
 
-  /* Show sun in dark mode, moon in light mode */
+  /* Show moon in dark mode, sun in light mode */
   .theme-icon-light { display: none; }
   .theme-icon-dark { display: inline; }
 

--- a/src/pages/cat/articles/[...slug].astro
+++ b/src/pages/cat/articles/[...slug].astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
 import ArticleLayout from '../../../layouts/ArticleLayout.astro';
+import { getReadingTime } from '../../../utils/reading-time';
 
 export async function getStaticPaths() {
   const articles = await getCollection('articles', ({ slug }) => {
@@ -15,6 +16,7 @@ export async function getStaticPaths() {
 
 const { article } = Astro.props;
 const { Content } = await article.render();
+const readingTime = getReadingTime(article.body || '');
 const lang = 'cat';
 ---
 
@@ -28,6 +30,7 @@ const lang = 'cat';
   tags={article.data.tags}
   lang={lang}
   slug={article.slug}
+  readingTime={readingTime}
 >
   <Content />
 </ArticleLayout>

--- a/src/pages/cat/index.astro
+++ b/src/pages/cat/index.astro
@@ -11,6 +11,19 @@ const featuredProjects = getFeaturedProjects().slice(0, 3);
 ---
 
 <Layout title="Inici" lang={lang}>
+  <script slot="head" type="application/ld+json" set:html={JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Ismael Martinez",
+    "url": "https://ismaelmartinez.me.uk",
+    "jobTitle": "Software Engineer",
+    "sameAs": [
+      "https://github.com/IsmaelMartinez",
+      "https://www.linkedin.com/in/imartinez",
+      "https://medium.com/@ismaelmartinez",
+      "https://dev.to/ismaelmartinez"
+    ]
+  })} />
   <Hero lang={lang} />
 
   <section class="section">

--- a/src/pages/cat/uses.astro
+++ b/src/pages/cat/uses.astro
@@ -1,0 +1,109 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import { useTranslations } from '../../i18n/translations';
+import { usesData } from '../../data/uses';
+
+const lang = 'cat';
+const t = useTranslations(lang);
+---
+
+<Layout title="Eines" lang={lang}>
+  <section class="section">
+    <div class="container">
+      <header class="page-header">
+        <h1 class="page-title">{t('uses.title')}</h1>
+        <p class="page-description">{t('uses.description')}</p>
+      </header>
+
+      {usesData.map(category => (
+        <div class="uses-category">
+          <h2 class="category-title">{category.title[lang]}</h2>
+          <ul class="uses-list">
+            {category.items.map(item => (
+              <li class="uses-item">
+                <div class="uses-item-name">
+                  {item.url ? (
+                    <a href={item.url} target="_blank" rel="noopener noreferrer">{item.name}</a>
+                  ) : (
+                    <span>{item.name}</span>
+                  )}
+                </div>
+                <p class="uses-item-description">{item.description[lang]}</p>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  </section>
+</Layout>
+
+<style>
+  .page-header {
+    margin-bottom: var(--space-2xl);
+  }
+
+  .page-title {
+    font-size: 2rem;
+    font-weight: 700;
+    margin-bottom: var(--space-md);
+  }
+
+  .page-description {
+    font-size: 1.125rem;
+    color: var(--color-text-muted);
+    max-width: 600px;
+  }
+
+  .uses-category {
+    margin-bottom: var(--space-2xl);
+  }
+
+  .category-title {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin-bottom: var(--space-lg);
+    padding-bottom: var(--space-sm);
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .uses-list {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-md);
+  }
+
+  .uses-item {
+    padding: var(--space-md) var(--space-lg);
+    background: var(--color-bg-secondary);
+    border: 1px solid var(--color-border);
+    border-radius: 0.75rem;
+    transition: border-color 0.2s ease;
+  }
+
+  .uses-item:hover {
+    border-color: var(--color-accent);
+  }
+
+  .uses-item-name {
+    font-weight: 600;
+    margin-bottom: var(--space-xs);
+  }
+
+  .uses-item-name a {
+    color: var(--color-text);
+    text-decoration: none;
+    transition: color 0.2s ease;
+  }
+
+  .uses-item-name a:hover {
+    color: var(--color-accent);
+  }
+
+  .uses-item-description {
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+    line-height: 1.5;
+  }
+</style>

--- a/src/pages/en/articles/[...slug].astro
+++ b/src/pages/en/articles/[...slug].astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
 import ArticleLayout from '../../../layouts/ArticleLayout.astro';
+import { getReadingTime } from '../../../utils/reading-time';
 
 export async function getStaticPaths() {
   const articles = await getCollection('articles', ({ slug }) => {
@@ -15,6 +16,7 @@ export async function getStaticPaths() {
 
 const { article } = Astro.props;
 const { Content } = await article.render();
+const readingTime = getReadingTime(article.body || '');
 const lang = 'en';
 ---
 
@@ -28,6 +30,7 @@ const lang = 'en';
   tags={article.data.tags}
   lang={lang}
   slug={article.slug}
+  readingTime={readingTime}
 >
   <Content />
 </ArticleLayout>

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -11,6 +11,19 @@ const featuredProjects = getFeaturedProjects().slice(0, 3);
 ---
 
 <Layout title="Home" lang={lang}>
+  <script slot="head" type="application/ld+json" set:html={JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Ismael Martinez",
+    "url": "https://ismaelmartinez.me.uk",
+    "jobTitle": "Software Engineer",
+    "sameAs": [
+      "https://github.com/IsmaelMartinez",
+      "https://www.linkedin.com/in/imartinez",
+      "https://medium.com/@ismaelmartinez",
+      "https://dev.to/ismaelmartinez"
+    ]
+  })} />
   <Hero lang={lang} />
 
   <section class="section">

--- a/src/pages/en/uses.astro
+++ b/src/pages/en/uses.astro
@@ -1,0 +1,109 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import { useTranslations } from '../../i18n/translations';
+import { usesData } from '../../data/uses';
+
+const lang = 'en';
+const t = useTranslations(lang);
+---
+
+<Layout title="Uses" lang={lang}>
+  <section class="section">
+    <div class="container">
+      <header class="page-header">
+        <h1 class="page-title">{t('uses.title')}</h1>
+        <p class="page-description">{t('uses.description')}</p>
+      </header>
+
+      {usesData.map(category => (
+        <div class="uses-category">
+          <h2 class="category-title">{category.title[lang]}</h2>
+          <ul class="uses-list">
+            {category.items.map(item => (
+              <li class="uses-item">
+                <div class="uses-item-name">
+                  {item.url ? (
+                    <a href={item.url} target="_blank" rel="noopener noreferrer">{item.name}</a>
+                  ) : (
+                    <span>{item.name}</span>
+                  )}
+                </div>
+                <p class="uses-item-description">{item.description[lang]}</p>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  </section>
+</Layout>
+
+<style>
+  .page-header {
+    margin-bottom: var(--space-2xl);
+  }
+
+  .page-title {
+    font-size: 2rem;
+    font-weight: 700;
+    margin-bottom: var(--space-md);
+  }
+
+  .page-description {
+    font-size: 1.125rem;
+    color: var(--color-text-muted);
+    max-width: 600px;
+  }
+
+  .uses-category {
+    margin-bottom: var(--space-2xl);
+  }
+
+  .category-title {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin-bottom: var(--space-lg);
+    padding-bottom: var(--space-sm);
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .uses-list {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-md);
+  }
+
+  .uses-item {
+    padding: var(--space-md) var(--space-lg);
+    background: var(--color-bg-secondary);
+    border: 1px solid var(--color-border);
+    border-radius: 0.75rem;
+    transition: border-color 0.2s ease;
+  }
+
+  .uses-item:hover {
+    border-color: var(--color-accent);
+  }
+
+  .uses-item-name {
+    font-weight: 600;
+    margin-bottom: var(--space-xs);
+  }
+
+  .uses-item-name a {
+    color: var(--color-text);
+    text-decoration: none;
+    transition: color 0.2s ease;
+  }
+
+  .uses-item-name a:hover {
+    color: var(--color-accent);
+  }
+
+  .uses-item-description {
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+    line-height: 1.5;
+  }
+</style>

--- a/src/pages/es/articles/[...slug].astro
+++ b/src/pages/es/articles/[...slug].astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
 import ArticleLayout from '../../../layouts/ArticleLayout.astro';
+import { getReadingTime } from '../../../utils/reading-time';
 
 export async function getStaticPaths() {
   const articles = await getCollection('articles', ({ slug }) => {
@@ -15,6 +16,7 @@ export async function getStaticPaths() {
 
 const { article } = Astro.props;
 const { Content } = await article.render();
+const readingTime = getReadingTime(article.body || '');
 const lang = 'es';
 ---
 
@@ -28,6 +30,7 @@ const lang = 'es';
   tags={article.data.tags}
   lang={lang}
   slug={article.slug}
+  readingTime={readingTime}
 >
   <Content />
 </ArticleLayout>

--- a/src/pages/es/index.astro
+++ b/src/pages/es/index.astro
@@ -11,6 +11,19 @@ const featuredProjects = getFeaturedProjects().slice(0, 3);
 ---
 
 <Layout title="Inicio" lang={lang}>
+  <script slot="head" type="application/ld+json" set:html={JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Ismael Martinez",
+    "url": "https://ismaelmartinez.me.uk",
+    "jobTitle": "Software Engineer",
+    "sameAs": [
+      "https://github.com/IsmaelMartinez",
+      "https://www.linkedin.com/in/imartinez",
+      "https://medium.com/@ismaelmartinez",
+      "https://dev.to/ismaelmartinez"
+    ]
+  })} />
   <Hero lang={lang} />
 
   <section class="section">

--- a/src/pages/es/uses.astro
+++ b/src/pages/es/uses.astro
@@ -1,0 +1,109 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import { useTranslations } from '../../i18n/translations';
+import { usesData } from '../../data/uses';
+
+const lang = 'es';
+const t = useTranslations(lang);
+---
+
+<Layout title="Herramientas" lang={lang}>
+  <section class="section">
+    <div class="container">
+      <header class="page-header">
+        <h1 class="page-title">{t('uses.title')}</h1>
+        <p class="page-description">{t('uses.description')}</p>
+      </header>
+
+      {usesData.map(category => (
+        <div class="uses-category">
+          <h2 class="category-title">{category.title[lang]}</h2>
+          <ul class="uses-list">
+            {category.items.map(item => (
+              <li class="uses-item">
+                <div class="uses-item-name">
+                  {item.url ? (
+                    <a href={item.url} target="_blank" rel="noopener noreferrer">{item.name}</a>
+                  ) : (
+                    <span>{item.name}</span>
+                  )}
+                </div>
+                <p class="uses-item-description">{item.description[lang]}</p>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  </section>
+</Layout>
+
+<style>
+  .page-header {
+    margin-bottom: var(--space-2xl);
+  }
+
+  .page-title {
+    font-size: 2rem;
+    font-weight: 700;
+    margin-bottom: var(--space-md);
+  }
+
+  .page-description {
+    font-size: 1.125rem;
+    color: var(--color-text-muted);
+    max-width: 600px;
+  }
+
+  .uses-category {
+    margin-bottom: var(--space-2xl);
+  }
+
+  .category-title {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin-bottom: var(--space-lg);
+    padding-bottom: var(--space-sm);
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .uses-list {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-md);
+  }
+
+  .uses-item {
+    padding: var(--space-md) var(--space-lg);
+    background: var(--color-bg-secondary);
+    border: 1px solid var(--color-border);
+    border-radius: 0.75rem;
+    transition: border-color 0.2s ease;
+  }
+
+  .uses-item:hover {
+    border-color: var(--color-accent);
+  }
+
+  .uses-item-name {
+    font-weight: 600;
+    margin-bottom: var(--space-xs);
+  }
+
+  .uses-item-name a {
+    color: var(--color-text);
+    text-decoration: none;
+    transition: color 0.2s ease;
+  }
+
+  .uses-item-name a:hover {
+    color: var(--color-accent);
+  }
+
+  .uses-item-description {
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+    line-height: 1.5;
+  }
+</style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,5 +1,5 @@
 :root {
-  /* Colors */
+  /* Colors (dark default) */
   --color-bg: #0f0f0f;
   --color-bg-secondary: #1a1a1a;
   --color-text: #e5e5e5;
@@ -26,9 +26,9 @@
   --nav-height: 4rem;
 }
 
-/* Light mode */
+/* Light mode — system preference (when no manual override) */
 @media (prefers-color-scheme: light) {
-  :root {
+  :root:not([data-theme="dark"]) {
     --color-bg: #fafafa;
     --color-bg-secondary: #f5f5f5;
     --color-text: #171717;
@@ -37,6 +37,17 @@
     --color-accent-hover: #1d4ed8;
     --color-border: #e5e5e5;
   }
+}
+
+/* Light mode — manual override */
+:root[data-theme="light"] {
+  --color-bg: #fafafa;
+  --color-bg-secondary: #f5f5f5;
+  --color-text: #171717;
+  --color-text-muted: #525252;
+  --color-accent: #2563eb;
+  --color-accent-hover: #1d4ed8;
+  --color-border: #e5e5e5;
 }
 
 /* Reset */
@@ -201,4 +212,59 @@ img {
 .link-card-content p {
   font-size: 0.875rem;
   color: var(--color-text-muted);
+}
+
+/* Print Stylesheet */
+@media print {
+  :root {
+    --color-bg: #fff;
+    --color-bg-secondary: #fff;
+    --color-text: #000;
+    --color-text-muted: #333;
+    --color-accent: #000;
+    --color-border: #ccc;
+  }
+
+  nav,
+  footer,
+  .skip-link,
+  .lang-switcher,
+  .konami-overlay,
+  .theme-toggle {
+    display: none !important;
+  }
+
+  body {
+    font-size: 12pt;
+    line-height: 1.5;
+  }
+
+  a {
+    color: #000;
+    text-decoration: underline;
+  }
+
+  a[href^="http"]::after {
+    content: " (" attr(href) ")";
+    font-size: 0.8em;
+    color: #555;
+  }
+
+  .container {
+    max-width: 100%;
+    padding: 0;
+  }
+
+  .article-content {
+    font-size: 11pt;
+  }
+
+  img {
+    max-width: 100% !important;
+    page-break-inside: avoid;
+  }
+
+  h1, h2, h3 {
+    page-break-after: avoid;
+  }
 }

--- a/src/utils/reading-time.ts
+++ b/src/utils/reading-time.ts
@@ -1,0 +1,7 @@
+const WORDS_PER_MINUTE = 200;
+
+export function getReadingTime(content: string): number {
+  const text = content.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim();
+  const wordCount = text.split(' ').filter(Boolean).length;
+  return Math.max(1, Math.ceil(wordCount / WORDS_PER_MINUTE));
+}


### PR DESCRIPTION
## Summary

This PR implements several site improvements focused on user experience, SEO, and developer tooling visibility. It adds a new `/uses` page showcasing development tools and hardware, introduces a dark/light mode toggle with localStorage persistence, enables smooth page transitions, and adds structured data markup for better search engine optimization.

## Key Changes

- **New `/uses` Page**: Created multilingual `/uses` pages (EN/ES/CAT) with categorized tools, software, and hardware. Data is centralized in `src/data/uses.ts` with full i18n support across 5 categories (Editor & Terminal, Languages & Frameworks, DevOps & Infrastructure, Productivity, Hardware).

- **Dark/Light Mode Toggle**: Added manual theme toggle button in navigation with localStorage persistence. Includes FOUC prevention script and respects system preferences when no manual override is set. Theme state persists across page navigations via View Transitions.

- **View Transitions**: Integrated Astro's `<ViewTransitions />` component for smooth page navigation. Added `astro:after-swap` event listeners to maintain state (theme, Konami code detection) across transitions.

- **Reading Time Indicator**: Implemented `getReadingTime()` utility function (word count ÷ 200) and integrated it into article headers across all locales.

- **JSON-LD Structured Data**: 
  - Added `Person` schema to all homepage locales with social links
  - Added `Article` schema to article pages with headline, description, dates, author, and keywords

- **Print Stylesheet**: Added comprehensive `@media print` styles hiding navigation/footer, optimizing typography, showing URLs after links, and preventing page breaks in images/headings.

- **Navigation Updates**: Reorganized nav actions into a flex container, added theme toggle button, and added `/uses` link to footer.

- **i18n Translations**: Added new translation keys for theme toggle, uses page, and reading time indicator across all three languages.

## Implementation Details

- Theme toggle uses `data-theme` attribute on root element with CSS selectors to show/hide sun/moon icons
- Reading time calculation strips HTML tags and counts words, with minimum of 1 minute
- View Transitions properly re-initialize theme toggle and Konami code listeners after navigation
- Uses page data structure supports optional URLs for items without external links (e.g., MacBook Pro)
- Print stylesheet uses `!important` for critical display:none rules to ensure proper hiding

https://claude.ai/code/session_013FpvSC6m4jMu1y2peC9SvC