### PR TITLE
Update content pipeline plan

### DIFF
--- a/docs/plans/2026-03-03-content-pipeline.md
+++ b/docs/plans/2026-03-03-content-pipeline.md
@@ -2,15 +2,38 @@
 
 ## In Progress: Observability Series
 
-Tracked in `docs/plans/2026-02-27-observability-series-design.md`. Two articles planned: OpenTelemetry Signals (article 1, drafted) and Observability for Agentic Systems (article 2, not started). Both need translations to es/cat once the English versions are finalised.
+Tracked in `docs/plans/2026-02-27-observability-series-design.md`. Two articles planned:
 
-## Next: AI-Assisted Open Source Maintenance
+Article 1, OpenTelemetry Signals — published (`draft: false`).
 
-Draft outline exists at `src/content/articles/en/ai-assisted-open-source-maintenance.mdx`. The structure is solid (seven sections, clear argument arc from "the project predates the tools" through to "transparency should be normalised"). What remains:
+Article 2, Observability for Agentic Systems — not started. Builds on the Signals article and the "Observability Expands" section from the Agentic EDA piece. Core argument: traditional observability tells you whether your system is healthy; agent-aware observability tells you whether decisions are stable, safe, and cost-effective. The triage bot (`github-issue-triage-bot`) provides a real working example — safety layers, agent audit log, escalation after 4 round-trips. Both need translations to es/cat once the English versions are finalised.
 
-- Convert bullet-point outlines into prose for each section. The inline comments already note the point each section should land on.
-- Add concrete examples from teams-for-linux: specific PRs, commit hashes, or issue threads that illustrate the claims (the CLAUDE.md invariant breakage, the Gemini triage bot, the "chill with updates" discussion).
-- Write the closing to tie back to the companion piece ("The AI Automation Trap" covers philosophy, this one covers practice).
-- Decide on tags and cross-links. Current tags look right. Consider linking to the Agentic EDA article if the observability series is published first.
-- Translate to es/cat after the English version is complete.
-- Set `draft: false` and confirm `publishedDate` before merging.
+## Teams for Linux Series
+
+Three articles forming a principles → workflow → tooling arc.
+
+### Article 1: Principles and Secure AI Usage (existing draft)
+
+Draft exists at `src/content/articles/en/ai-assisted-open-source-maintenance.mdx` (`draft: true`). The prose is largely complete. The article focuses on why AI is used, what it can and cannot replace, and why transparency matters. Light refocus needed once Article 2 exists: add forward references to the workflow article and ensure the split between "why" (this article) and "how" (article 2) is clean. Ties back to "The AI Automation Trap" as the philosophical companion. Translate to es/cat after finalising. Set `draft: false` and confirm `publishedDate` before merging.
+
+### Article 2: The Actual Workflow (not started)
+
+Detailed walkthrough of how AI is used day-to-day in the teams-for-linux project. Covers the practical flow: how CLAUDE.md governs behaviour, how dependency upgrades and security patches are handled, how features move from decision to implementation with AI assistance, and what the review/release cycle looks like. This is the "how" to Article 1's "why."
+
+### Article 3: Standardising Issue Triage with AI (not started)
+
+Covers the `github-issue-triage-bot` project. How the multi-phase triage pipeline works (template parsing, vector search, duplicate detection, roadmap matching, miscategorisation checks). The Enhancement Researcher agent and its shadow repo workflow. Safety layers (structural validator + LLM reviewer) and the escalation model. Silent mode and the dashboard. Follows the same principles from Article 1 applied to a new problem: standardising the issue/enhancement process with AI while keeping human oversight.
+
+## Bonnie Wee Plot: Vibe Coding an Allotment App (not started)
+
+Standalone article about `bonnie-wee-plot`, a Next.js allotment management app that was entirely vibe-coded with AI. Covers learnings from the experience, what worked, what didn't, and why sharing a personal project publicly is worthwhile even when it's built primarily for yourself. Contrast with the disciplined AI usage in the t4l series — this is the other end of the spectrum.
+
+## Backlog (maybe)
+
+### Local Brain: Delegating to Local Models (not started)
+
+About the `local-brain` Claude Code plugin marketplace. A CLI tool and plugin that lets Claude Code delegate read-only codebase exploration to local Ollama models — no cloud round-trips, full privacy. Uses Smolagents as the agent framework with path-jailed tools and a two-layer security model (trusted tool layer + LLM sandbox). Has OpenTelemetry tracing built in. Interesting angles: the separation of concerns (web research stays with Claude, local code stays local), the security model design, building a Claude Code plugin, and using Smolagents for code execution.
+
+### AI Model Advisor: Recommending Efficient Models (not started)
+
+About the `ai-model-advisor` project. A browser-only PWA that helps users find AI models for their task, prioritising smaller and more efficient options. Uses MiniLM embeddings (~23MB) for task classification with keyword fallback, runs entirely client-side with no backend. Covers the environmental scoring system (4 tiers by model size), the design decision to keep everything in the browser, and the offline-first PWA approach. Could tie into the broader theme of responsible AI usage — choosing the right-sized model rather than defaulting to the biggest one.

--- a/src/content/articles/en/ai-assisted-open-source-maintenance.mdx
+++ b/src/content/articles/en/ai-assisted-open-source-maintenance.mdx
@@ -1,6 +1,6 @@
 ---
 title: "AI-Assisted Open Source: What Changes and What Doesn't"
-description: "How AI tooling fits into maintaining a 7-year open-source project — what it accelerates, what it can't replace, and why the CLAUDE.md file exists."
+description: "How AI tooling fits into maintaining an eight-year open-source project — what it accelerates, what it can't replace, and why the CLAUDE.md file exists."
 publishedDate: 2026-03-03
 tags: ["AI", "Open Source", "Software Development", "Teams for Linux"]
 draft: true
@@ -10,27 +10,23 @@ draft: true
 
 teams-for-linux started in 2018. That's more than five years before any AI coding tool existed. I built an Electron wrapper for Microsoft Teams because Microsoft dropped official Linux support and thousands of developers needed a working client. The project grew organically to over 4,400 stars, 315 forks, and 30 contributors over the years.
 
-AI adoption came much later. It's a tool choice I made to keep up with the demands of maintaining a project this size, not the origin story. The timeline matters because people sometimes look at a repository, see signs of AI tooling, and assume the whole thing was generated. It wasn't. The project has seven years of history, community, and hard-won architectural decisions behind it.
+AI adoption came much later. It's a tool choice I made to keep up with the demands of maintaining a project this size, not the origin story. The timeline matters because people sometimes look at a repository, see signs of AI tooling, and assume the whole thing was generated. It wasn't. The project has eight years of history, community, and hard-won architectural decisions behind it.
 
 ## What CLAUDE.md Actually Is
 
 When people spotted the CLAUDE.md file in the repository, some assumed it meant the project was AI-authored. That's a misunderstanding of what the file does.
 
-CLAUDE.md is a configuration file, much like `.editorconfig` or `tsconfig.json`. It tells the AI tool how to behave in this specific codebase. It documents architectural decisions, module boundaries, and critical invariants — like the `trayIconRenderer`/`mqttStatusMonitor` initialisation requirement that has been accidentally broken multiple times by contributors who didn't know about the dependency.
+CLAUDE.md is a configuration file, much like `.editorconfig` or `tsconfig.json`. It tells the AI tool how to behave in this specific codebase: architectural decisions, module boundaries, critical invariants, forbidden patterns. Every codebase has unwritten rules. CLAUDE.md makes them explicit. It's not a sign of AI authorship. It's a sign of AI discipline.
 
-The file encodes project-specific knowledge so the AI tool respects existing patterns instead of inventing new ones. Every codebase has unwritten rules. CLAUDE.md makes them explicit. It's not a sign of AI authorship. It's a sign of AI discipline.
+What goes into that file and how it evolves over time is [its own story](/en/articles/ai-assisted-open-source-workflow), but the key point is this: the file exists because AI without constraints will invent new patterns rather than respecting existing ones. In a project with eight years of accumulated decisions, that's a problem worth solving.
 
 ## What AI Actually Accelerates
 
-The tasks AI handles well are the ones that would otherwise burn out a solo maintainer.
+The tasks AI handles well are the ones that would otherwise burn out a solo maintainer: implementing well-understood features, bumping dependencies, responding to security advisories, generating test scaffolding, and exploring unfamiliar APIs. Once I've decided what to build and how it should work, the mechanical translation of intent into code goes faster with AI assistance. The [day-to-day workflow](/en/articles/ai-assisted-open-source-workflow) shows what this looks like in practice.
 
-Implementation of well-understood features is the obvious one. Once I've decided what to build and how it should work, the actual coding — the mechanical translation of intent into code — goes faster with AI assistance. Boilerplate, test scaffolding, and documentation updates fall into the same category. They're necessary work, but they don't require creative judgement.
+The time savings compound in unglamorous places. The npm ecosystem pushes security advisories multiple times a week. Each one needs evaluation, patching, testing, and release. Electron's API surface is vast, Wayland has its own quirks, and Trusted Types introduced a whole new set of constraints. Without tooling, this maintenance work alone can consume most of a maintainer's available hours. With it, I can get through a week's worth of advisories in an afternoon.
 
-Dependency upgrades and security patch responses are where the time savings really add up. The npm ecosystem pushes security advisories multiple times a week. Each one needs evaluation, patching, testing, and release. Without tooling, that alone can consume most of a maintainer's available hours.
-
-Exploring unfamiliar APIs is another area where AI shines. Electron's API surface is vast, Wayland has its own quirks, and Trusted Types introduced a whole new set of constraints. Having a tool that can quickly surface relevant documentation and usage patterns cuts the exploration time significantly.
-
-I also built a Gemini-powered triage bot for GitHub issues. When a project gets hundreds of issues, sorting signal from noise manually isn't sustainable. The bot handles initial categorisation so I can focus on the issues that actually need human attention.
+I also built a [triage bot](/en/articles/standardising-issue-triage-with-ai) that uses vector search and Gemini to help sort GitHub issues — surfacing known solutions, flagging duplicates, and prompting reporters for missing information. That's its own story, but the principle is the same: AI handles the searching and summarising so I can focus on the decisions.
 
 ## What AI Cannot Replace
 
@@ -52,9 +48,7 @@ And then there's saying no to feature requests. That's perhaps the hardest part 
 
 teams-for-linux is a single-maintainer project with thousands of active users. That ratio is the core challenge.
 
-Without AI tooling, the maths doesn't work. Responding to issues takes longer. Releases happen less frequently. Security patches sit in the queue. Eventually the backlog grows faster than one person can address it, and the project gets abandoned. That's not hypothetical — it's the default outcome for popular single-maintainer projects.
-
-With AI tooling, I can keep up with security patches, Electron upgrades, user reports, and still ship new features. The tool handles the mechanical work so I can spend my limited time on the decisions and community interactions that actually require a human.
+Without AI tooling, the maths doesn't work. The backlog grows faster than one person can address it, and the project gets abandoned. That's not hypothetical — it's the default outcome for popular single-maintainer projects.
 
 The alternative to AI-assisted maintenance isn't "write everything by hand." It's "let issues pile up and eventually walk away." For solo open-source maintainers, AI is a sustainability tool, not a shortcut.
 

--- a/src/content/articles/en/ai-assisted-open-source-maintenance.mdx
+++ b/src/content/articles/en/ai-assisted-open-source-maintenance.mdx
@@ -40,7 +40,7 @@ Architectural decisions sit in the same category. When to refactor versus when t
 
 Release judgement is more nuanced than it sounds. Is this build ready? Should I batch more fixes first? Is the Wayland fix stable enough to ship, or does it need another week of testing? These decisions require context that no tool has access to.
 
-Understanding upstream changes is a constant challenge. The Teams web app changes without notice, and defensive coding against those changes requires deep domain knowledge about what Microsoft is likely to do and how their platform evolves. AI doesn't know what Microsoft shipped last Tuesday.
+Understanding upstream changes is a constant challenge. The Teams web app changes without notice, and defensive coding against those changes requires deep domain knowledge about what Microsoft is likely to do and how their platform evolves. AI doesn't know what Microsoft shipped last Tuesday. Worse, it doesn't know when a problem is unsolvable within the project's constraints — it will keep proposing fixes for things that can't be fixed because Microsoft controls the upstream. Recognising those boundaries and stopping the cycle is a human skill.
 
 And then there's saying no to feature requests. That's perhaps the hardest part of maintaining a popular project, and it's entirely a human skill.
 

--- a/src/content/articles/en/ai-assisted-open-source-workflow.mdx
+++ b/src/content/articles/en/ai-assisted-open-source-workflow.mdx
@@ -1,0 +1,91 @@
+---
+title: "AI-Assisted Open Source: The Actual Workflow"
+description: "A detailed walkthrough of how AI tooling fits into the day-to-day maintenance of teams-for-linux — from CLAUDE.md to dependency upgrades to release decisions."
+publishedDate: 2026-03-10
+tags: ["AI", "Open Source", "Software Development", "Teams for Linux"]
+draft: true
+---
+
+{/* Series context: second article in the t4l series. Article 1 ("What Changes and What Doesn't") covers principles. This one covers the how. Article 3 covers the triage bot. */}
+
+{/* Tone: practical, specific, first-person. Show-don't-tell. Needs anecdotes and moments of frustration, not just process steps. The reader should finish knowing exactly how AI fits into the maintenance loop AND find it engaging to read. */}
+
+## From Principles to Practice
+
+{/* Brief bridge from Article 1, but lead with the surprising insight rather than burying it.
+
+The biggest change isn't that coding is faster. It's where the time goes. Before AI, most of my maintenance hours went to writing code. Now most go to triaging issues, talking to the community, and making decisions about what to build. The actual coding takes the least time of anything I do in a week.
+
+That inversion is the story this article tells. The workflow is not "ask AI to do everything." It is a structured loop — decide, constrain, execute, review — where the constraints are what make it work. */}
+
+## CLAUDE.md as the Rulebook
+
+{/* Article 1 introduced CLAUDE.md as a concept — a configuration file that makes unwritten rules explicit. This section goes inside the file and shows what's actually in it.
+
+Focus on the contents and how they evolve, not the "what is it" explanation (Article 1 already did that).
+
+The specific invariants: the trayIconRenderer/mqttStatusMonitor initialisation order. Why that's in the file — because contributors (and AI) have broken it multiple times, and the dependency is not obvious from the code.
+
+Module boundaries: where code should live, what depends on what. The AI will invent new patterns if you don't tell it which patterns already exist.
+
+Forbidden patterns: things the AI should never do. Removing backwards compatibility without explicit instruction. Changing Electron configuration defaults. These are the guardrails that prevent AI from being "helpfully destructive."
+
+Testing expectations: what needs tests, what patterns to follow.
+
+The file is living documentation. When a new invariant is discovered — usually through a bug — it gets added. When a pattern is retired, it gets removed. A concrete example: the time a specific invariant was broken, the bug that resulted, and the CLAUDE.md entry that prevents it from happening again. */}
+
+## The Dependency Upgrade Loop
+
+{/* The most common workflow, and the one where AI saves the most cumulative time.
+
+Walk through a real example — a recent Electron major upgrade or a security advisory response.
+
+The flow: advisory arrives → maintainer evaluates severity and relevance (is this a real risk for an Electron app, or a transitive dependency that doesn't apply?) → if action needed, AI handles the upgrade (bumps version, runs tests, checks changelog for breaking changes) → maintainer reviews the diff and manually tests the Electron app (no automated test covers "does Teams still load after this Electron bump?") → commit with Co-authored-by tag → release decision is separate.
+
+The human parts are steps 1 (evaluate), 3 (review), and 4 (release). The AI part is step 2 (execute). The loop is fast because the mechanical part is fast, not because the decisions are skipped.
+
+This is also where "does Teams still load?" comes in as the ultimate integration test that no AI can perform — it requires launching the app, logging in, and checking that the web client renders correctly. */}
+
+## Feature Implementation Flow
+
+{/* How a feature goes from idea to merged code.
+
+Decision: maintainer decides what to build based on issues, community feedback, and project direction. AI has no input here.
+
+Design: maintainer sketches the approach — often in an issue comment or PR description. For complex features, writes an ADR.
+
+Implementation: AI writes the code following CLAUDE.md constraints. This is iterative — maintainer reviews, requests changes, AI adjusts. Not a single pass.
+
+Testing: AI generates tests, maintainer reviews for meaningful coverage (not just line count — are these tests that would actually catch regressions?).
+
+Review: final manual review of the full diff. Electron-specific gotchas, Wayland compatibility, Trusted Types compliance.
+
+The key insight: AI compresses implementation and testing from days to hours. But deciding, designing, and reviewing take the same time they always did. The total cycle is faster, but the human-time-to-machine-time ratio has flipped. */}
+
+## Handling Upstream Changes
+
+{/* This is where AI is least helpful and where the section should have the most voice.
+
+Microsoft doesn't publish changelogs for the Teams web client. When something breaks — and it breaks regularly — the workflow is reproduce, diagnose, fix. AI can help with the fix, but diagnosing what Microsoft changed requires domain knowledge and years of experience with the platform's quirks.
+
+Concrete example: a recent upstream breakage. What broke, how the maintainer figured out what changed, and how the fix was implemented. This should read as a war story, not a process description.
+
+The honest admission: this is the part of maintenance that still takes as long as it ever did. AI doesn't help when the problem is "what did Microsoft change on their end this week?" */}
+
+## Quality Gates and Release Judgement
+
+{/* Merged from the previous "Review Discipline" and "Release Cadence" sections — they're both about quality gates at different stages.
+
+Review discipline: every AI-generated change goes through the same review as a human contribution. The Co-authored-by tag makes it clear which commits involved AI. What the maintainer looks for: CLAUDE.md compliance, Electron edge cases, behaviour preservation, meaningful tests, and readability for future contributors. That last point matters — AI can write code that works but is hard for humans to follow.
+
+Release cadence: the "chill with updates" story. Users pushed back on too-frequent releases. The maintainer had to read the room, understand the frustration, and adjust. AI makes it easier to batch changes (individual changes are faster), but the release decision — is this ready? should I wait for more fixes? — is entirely human.
+
+This is pure community management. No AI tool can tell you when your users are fatigued. */}
+
+## Closing
+
+{/* This workflow is not about using AI to write code faster. It is about using AI to make solo maintenance sustainable. The time inversion — from coding being the bottleneck to deciding being the bottleneck — is the real shift.
+
+The next article in this series applies these same principles to a different problem: [standardising the issue triage process with AI](/en/articles/standardising-issue-triage-with-ai).
+
+For the principles behind these workflow choices, see [the companion article](/en/articles/ai-assisted-open-source-maintenance). */}

--- a/src/content/articles/en/ai-assisted-open-source-workflow.mdx
+++ b/src/content/articles/en/ai-assisted-open-source-workflow.mdx
@@ -32,7 +32,9 @@ Forbidden patterns: things the AI should never do. Removing backwards compatibil
 
 Testing expectations: what needs tests, what patterns to follow.
 
-The file is living documentation. When a new invariant is discovered — usually through a bug — it gets added. When a pattern is retired, it gets removed. A concrete example: the time a specific invariant was broken, the bug that resulted, and the CLAUDE.md entry that prevents it from happening again. */}
+The file is living documentation. When a new invariant is discovered — usually through a bug — it gets added. When a pattern is retired, it gets removed. A concrete example: the time a specific invariant was broken, the bug that resulted, and the CLAUDE.md entry that prevents it from happening again.
+
+Keeping documentation relevant and up to date is not optional in this workflow — it's load-bearing. The triage bot uses a vector database seeded from the project's docs and issue history to surface solutions, identify duplicates, and provide context. If the docs are stale, the bot gives stale answers. CLAUDE.md constrains the AI agent; the broader documentation feeds it. Both need maintenance. */}
 
 ## The Dependency Upgrade Loop
 
@@ -48,19 +50,21 @@ This is also where "does Teams still load?" comes in as the ultimate integration
 
 ## Feature Implementation Flow
 
-{/* How a feature goes from idea to merged code.
+{/* How a feature or non-trivial issue goes from idea to merged code. The workflow has more AI involvement than just "write the code" — it starts with research.
 
-Decision: maintainer decides what to build based on issues, community feedback, and project direction. AI has no input here.
+Research phase: for anything beyond a trivial fix, the first step is asking an agent to research the problem. The agent investigates the codebase, the issue history, and the relevant docs to understand the scope. If the change isn't straightforward, the agent identifies potential approaches, validates them with spikes, and produces a plan. This is not blind delegation — the maintainer reads the plan and guides the agent around it, correcting direction and catching misunderstandings before any implementation starts.
 
-Design: maintainer sketches the approach — often in an issue comment or PR description. For complex features, writes an ADR.
+This research step matters because it surfaces problems early. The agent might discover that the proposed approach conflicts with an architectural invariant, or that a similar feature was attempted and abandoned, or that the change touches a part of the codebase with upstream dependencies that constrain the solution. Better to find that out in research than in implementation.
 
-Implementation: AI writes the code following CLAUDE.md constraints. This is iterative — maintainer reviews, requests changes, AI adjusts. Not a single pass.
+Decision: maintainer decides what to build based on the research output, community feedback, and project direction. The research informs the decision, but the decision is human.
 
-Testing: AI generates tests, maintainer reviews for meaningful coverage (not just line count — are these tests that would actually catch regressions?).
+Implementation: AI writes the code following CLAUDE.md constraints and the validated plan. This is iterative — maintainer reviews, requests changes, AI adjusts. Not a single pass.
 
-Review: final manual review of the full diff. Electron-specific gotchas, Wayland compatibility, Trusted Types compliance.
+Review: every code change is manually reviewed. All of it. CLAUDE.md compliance, Electron edge cases, behaviour preservation, meaningful tests, readability for future contributors. The Co-authored-by tag makes it clear which commits involved AI.
 
-The key insight: AI compresses implementation and testing from days to hours. But deciding, designing, and reviewing take the same time they always did. The total cycle is faster, but the human-time-to-machine-time ratio has flipped. */}
+The hardest part: knowing when the AI is trying to fix something unfixable. The project has inherent limitations — it wraps a web client that Microsoft controls, running inside Electron with its own constraints. AI doesn't understand "we can't fix this because Microsoft won't let us." It will keep proposing solutions to problems that have no solution within the project's boundaries. Recognising that and stopping the cycle is a human skill.
+
+The key insight: AI compresses research and implementation from days to hours. But deciding, guiding the research, and reviewing take the same time they always did. The human-time-to-machine-time ratio has flipped. */}
 
 ## Handling Upstream Changes
 

--- a/src/content/articles/en/observability-for-agentic-systems.mdx
+++ b/src/content/articles/en/observability-for-agentic-systems.mdx
@@ -1,0 +1,92 @@
+---
+title: "Observability for Agentic Systems"
+description: "Traditional observability tells you whether your system is healthy. Agent-aware observability tells you whether decisions are stable, safe, and cost-effective."
+publishedDate: 2026-03-10
+tags: ["Observability", "Agentic AI", "OpenTelemetry", "AI"]
+draft: true
+---
+
+{/* Series context: third observability article, following "Observability with OpenTelemetry" (fundamentals) and "OpenTelemetry Signals" (traces, metrics, logs, baggage). Also builds on the "Observability Expands" section from the Agentic EDA article. */}
+
+{/* Tone: conceptual with concrete examples, same style as the signals article. No runnable code, but specific enough that a reader could implement the patterns. */}
+
+## The Assumption That Breaks
+
+{/* The Signals article ended with: "All of these signals share one assumption: the system being observed is deterministic." This article picks up from that line.
+
+OpenTelemetry signals assume same input, same output. Traces show the path, metrics show health, logs explain failures. All of this works because the system is predictable.
+
+Agents break that assumption. A service that uses an LLM can produce a different decision for the same input depending on model version, prompt version, retrieved context, temperature, and thinking time.
+
+The question is not whether we need new signals. The existing signals are fine. The question is what new dimensions we need to observe, and what patterns help us do it without drowning in data. */}
+
+## What Changes When Decisions Are Probabilistic
+
+{/* Walk through what happens to each existing signal when a service is non-deterministic. Keep this focused — it bridges from the Signals article to the new dimensions.
+
+Traces still show the path, but now the path can vary for identical inputs. A trace through an agent might include tool calls, retrieval steps, and reasoning loops that differ every time.
+
+Metrics still show aggregate health, but now you need new metrics: token usage, cost per decision, confidence distributions, escalation rates, policy rejection rates.
+
+Logs still explain what happened, but now "what happened" includes the reasoning chain, not just the outcome. Logging the full chain is expensive. Logging only the outcome loses the explanation. This is the tension that drives the new dimensions.
+
+Baggage becomes more important — propagating agent context (model version, prompt version, session ID) downstream so every service can attribute its telemetry to the right agent configuration. */}
+
+## New Observability Dimensions
+
+{/* Each dimension is a reusable pattern. Vary the treatment — give more space to the most important ones, not equal weight to all.
+
+Cost observability (most space): tokens consumed, cost per decision, cost per workflow. This is a first-class metric, not an afterthought. In deterministic systems, the cost of processing an event is predictable. In agent systems, a prompt change can silently double token usage. Cost must be attributed to the workflow, not buried in a cloud bill. Example: an enrichment agent that silently doubles token usage after a prompt change, and nobody notices because cost is treated as infrastructure rather than per-decision.
+
+Decision stability (significant space): are repeated invocations with the same input converging on the same output? Track decision variance over time. This is the observability dimension that has no equivalent in deterministic systems. Example: a triage bot classifying the same issue template differently across model updates — the input didn't change, but the output did.
+
+Escalation and rejection rates (moderate space): how often do decisions get rejected by policy gates or escalated to humans? Rising rejection rates mean the agent is drifting from acceptable behaviour. This is the bridge between observability and governance. Example: safety layers catching more outputs over time as a leading indicator of model drift.
+
+Confidence tracking (brief): if the agent reports confidence, track the distribution. Drops in confidence are leading indicators of upstream changes or context pollution.
+
+Tool usage patterns (brief): which tools does the agent call, how often, in what order? Drift signals prompt regression. Example: an agent that starts calling a fallback API on every request instead of the primary.
+
+Feedback loop detection (brief): correlation IDs, causation chains, and intent TTLs. Track chain depth and total reasoning cost per workflow. This connects back to the feedback loop section in the Agentic EDA article. */}
+
+## Antipatterns
+
+{/* Three antipatterns, kept punchy. These should feel like lessons learned, not a checklist.
+
+Observing outputs without observing reasoning: you know the agent said "duplicate issue" but not why. Without the reasoning chain, you cannot debug drift. The fix is not to log everything — it is to log decision-relevant context (what was retrieved, what the confidence was, which tools were called) without logging the full chain.
+
+Treating token cost as infrastructure cost: token cost varies per decision. Aggregating it into a monthly cloud bill hides the information you need. Attribution to the workflow is what makes cost observable.
+
+Sampling agent traces like deterministic traces: agent traces are high-variance. Uniform sampling loses the interesting cases — the expensive ones, the low-confidence ones, the escalated ones. Sample by confidence, cost, or escalation status instead. */}
+
+## The Four-Layer Model Revisited
+
+{/* Tie back to the four-layer model from the Agentic EDA article (semantics, transport, execution, governance). Show how each observability dimension maps to a layer:
+
+Semantics: decision stability, confidence tracking — is the agent making coherent decisions?
+Transport: feedback loop detection, correlation chains — are messages amplifying in unexpected ways?
+Execution: cost observability, tool usage patterns — what is the agent actually doing and at what cost?
+Governance: escalation rates, policy rejection rates — is the agent staying within acceptable bounds?
+
+Agent-aware observability is not a separate system. It extends the same architectural layers through new dimensions. The architecture doesn't change — the questions you ask of it do. */}
+
+## A Real Example: The Triage Bot
+
+{/* Brief walkthrough of the github-issue-triage-bot as a concrete case study. Keep it short — the triage bot gets [its own article](/en/articles/standardising-issue-triage-with-ai).
+
+The bot has a multi-phase pipeline where each phase is observable through standard traces and metrics. But the interesting observability is in the agent dimensions:
+
+Decision stability: does the bot classify the same issue type consistently across model updates?
+Cost: how many tokens does each triage consume? Does the Enhancement Researcher agent's multi-round research stay within budget?
+Governance: the structural validator and LLM reviewer act as observable policy gates. Their rejection rates are a metric.
+Escalation: the 4-round-trip boundary is an explicit observability threshold — if the agent can't converge in 4 rounds, it hands off to a human.
+Silent mode + dashboard: aggregate observability before the bot is allowed to act publicly. Observability as a governance gate.
+
+One or two paragraphs, not a full walkthrough. The point is to show the dimensions applied to something real, not to explain the triage bot. */}
+
+## Conclusion
+
+{/* Traditional observability answers "is the system healthy?" Agent-aware observability answers "are the decisions stable, safe, and cost-effective?"
+
+The signals are the same. The dimensions are new. And the architectures that get this right will be the ones where agents earn trust incrementally — observed every step of the way.
+
+Cross-link to [observability fundamentals](/en/articles/observability-with-opentelemetry), the [signals article](/en/articles/opentelemetry-signals), and the [agentic EDA article](/en/articles/integrating-agentic-systems-into-event-driven-architectures). */}

--- a/src/content/articles/en/standardising-issue-triage-with-ai.mdx
+++ b/src/content/articles/en/standardising-issue-triage-with-ai.mdx
@@ -85,9 +85,23 @@ A feature request: issue comes in for a capability that's partially on the roadm
 
 These should be based on real (or realistic) examples. */}
 
+## Where This Is Going
+
+{/* The current state is: the bot helps the maintainer triage faster. The future state is: the bot helps users directly.
+
+If AI can surface a known solution to a user's problem — a workaround, a troubleshooting step, a link to the right documentation — without the maintainer being involved at all, the user gets a faster response and a better experience. That's the goal: move the triage bot from "helps the maintainer" to "helps the user, with the maintainer overseeing."
+
+This is a meaningful shift. It means sharing more of what happens under the hood with users. If the bot can solve your problem, why wait for a human to relay the answer?
+
+But not everyone is comfortable with that. Some users don't want to interact with a bot. Some will distrust automated responses on principle. The transparency measures — the bot identifying itself as automated, the dashboard, the safety layers — are designed to build trust incrementally, but trust can't be forced.
+
+The vector database is the foundation for this. The bot's ability to surface useful answers depends entirely on the quality and currency of the documentation and issue history it's seeded with. Stale docs mean stale answers. Keeping the knowledge base current is not a nice-to-have — it's what makes the difference between a bot that helps and a bot that wastes people's time.
+
+The hardest constraint remains the same one from the [workflow article](/en/articles/ai-assisted-open-source-workflow): knowing when AI is trying to fix something unfixable. The project wraps a web client controlled by Microsoft, inside Electron. Some problems have no solution within those boundaries. A bot that keeps suggesting workarounds for an upstream limitation erodes trust faster than one that says "this is a known limitation, here's the context." Teaching the system to recognise its own boundaries is the ongoing challenge. */}
+
 ## Closing
 
-{/* The triage bot is not about replacing the maintainer's judgement. It is about giving the maintainer better information, faster.
+{/* The triage bot is not about replacing the maintainer's judgement. It is about giving the maintainer — and increasingly the users — better information, faster.
 
 Every design decision — silent mode, safety layers, the 4-round-trip boundary, the dashboard, the single consolidated comment — exists to keep the human in control while letting AI handle the searching, comparing, and summarising.
 

--- a/src/content/articles/en/standardising-issue-triage-with-ai.mdx
+++ b/src/content/articles/en/standardising-issue-triage-with-ai.mdx
@@ -1,0 +1,94 @@
+---
+title: "AI-Assisted Open Source: Standardising Issue Triage"
+description: "How the GitHub Issue Triage Bot brings structure to open source issue management — multi-phase pipelines, safety layers, and human oversight by design."
+publishedDate: 2026-03-10
+tags: ["AI", "Open Source", "Software Development", "Teams for Linux", "Agentic AI"]
+draft: true
+---
+
+{/* Series context: third article in the t4l series. Article 1 covers principles, Article 2 covers the day-to-day workflow. This one applies those principles to issue management. */}
+
+{/* Tone: practical with architectural detail, but needs the same first-person voice as Articles 1 and 2. Include "I tried X and it didn't work" moments. Not a design doc. */}
+
+## The Problem: Issue Overload
+
+{/* A project with 4,400+ stars and active users generates a constant stream of issues. Bug reports missing reproduction steps, feature requests that duplicate existing roadmap items, questions mislabelled as bugs, genuine duplicates of known issues.
+
+For a solo maintainer, manually triaging every issue is not sustainable. But automated triage that gets it wrong — miscategorising, missing duplicates, posting unhelpful comments — is worse than no triage at all.
+
+Weave the design principles into the problem statement rather than separating them. The challenge demanded a specific approach: the bot proposes, never acts (it never closes issues, changes labels, or does anything irreversible). It identifies itself as automated. And it started in silent mode — storing results in a database for dashboard review before it was ever allowed to post publicly. Trust earned through observation, not assumed.
+
+This is the same "AI proposes, human decides" principle from the [companion article](/en/articles/ai-assisted-open-source-maintenance), applied to a new domain. That's what led to the github-issue-triage-bot. */}
+
+## The Triage Pipeline
+
+{/* Walk through the phases, but vary the treatment. Not equal weight on each.
+
+Phase 1 — Template Completeness: deterministic, no LLM. Parses the issue body against the bug report form template and checks for missing reproduction steps, debug logs, expected behaviour. One or two sentences. The point: not everything needs an LLM.
+
+Phases 2 and 3 — Known Solutions and Duplicate Detection: these share a pattern (pgvector similarity search followed by Gemini analysis). Phase 2 searches troubleshooting docs for known solutions. Phase 3 searches past issues for duplicates. In both cases, the bot suggests — it never declares something solved or duplicate. That's a maintainer call. Discuss them together to avoid repetition of the vector-search-plus-LLM pattern.
+
+Phase 4a — Enhancement Context: this is the most interesting phase and deserves the most space. For feature requests, it searches roadmap items, ADRs, and research documents. If someone requests something that's already on the roadmap, the bot surfaces that context. If a similar request was previously rejected with reasoning, the bot surfaces the reasoning. This saves the maintainer from re-explaining decisions and gives the reporter immediate context they wouldn't otherwise have.
+
+Phase 4b — Miscategorisation: quick. Checks whether the issue is mislabelled (a question as a bug, a bug as a feature request). Suggests recategorisation.
+
+All phases consolidate into a single markdown comment. One comment, not five. This was a deliberate design choice — multiple bot comments would create noise rather than reduce it. */}
+
+## The Enhancement Researcher Agent
+
+{/* This is the most novel part of the system and should get the most space.
+
+For enhancement issues with a configured shadow repo, the bot creates a mirror issue in a private shadow repository and posts a context brief: a summary of the enhancement request plus relevant ADRs, roadmap items, and similar past issues from vector search.
+
+The maintainer controls what happens next through explicit signals:
+- "research" triggers full Gemini-powered research synthesis with multiple approaches, trade-offs, and recommendations.
+- "use as context" acknowledges the brief without triggering full research.
+- "reject" discards.
+
+The full research pipeline supports revision cycles, PR creation, and promotion back to the public issue. Every step requires an explicit human signal.
+
+This is the ["agent as decision emitter" pattern](/en/articles/integrating-agentic-systems-into-event-driven-architectures) applied concretely. The agent proposes, the maintainer signals, the agent executes within the signalled scope.
+
+Include a personal moment here: what prompted building the shadow repo approach? Was there a bad experience with an earlier version? What problem did it solve that the simpler pipeline didn't? */}
+
+## Safety Layers and Escalation
+
+{/* Two safety layers before any output is posted.
+
+Structural validator: deterministic and fast. Length limits, URL allowlists, mention blocking (the bot must never @-mention a user — that would be a terrible experience), control character detection.
+
+LLM reviewer: a second LLM evaluating the first LLM's output for relevance, tone, and prompt injection detection. If either layer rejects, the output is not posted and the rejection is logged.
+
+The 4-round-trip boundary: if the agent reaches 4 round-trips in a research session without progressing to review, it escalates to the maintainer. This prevents token-burning loops and forces the system to admit when it's stuck.
+
+Personal note: what prompted the 4-round-trip boundary? Was there an early research session that spiralled? How was the number chosen? */}
+
+## The Dashboard: Observability as Governance
+
+{/* A daily-generated dashboard shows triage activity, phase hit rates, reaction metrics, and agent session status.
+
+Before the bot was allowed to post publicly, the dashboard was the only way to evaluate its behaviour. This is observability applied to the bot itself — not just "is it running?" but "is it helpful?"
+
+How often does each phase fire? What's the hit rate for known solutions vs duplicates? How are users reacting to the bot's comments? Are agent sessions completing, escalating, or timing out?
+
+Silent mode + dashboard = the bot earns trust through demonstrated performance. This is the same incremental-trust approach from the design principles, made concrete through tooling.
+
+The infrastructure behind this (Go on Cloud Run, Neon PostgreSQL with pgvector, GitHub App auth, Workload Identity Federation, Terraform) matters for reproducibility but isn't the interesting part of the story. Mention it in a sentence or two here rather than giving it its own section. */}
+
+## What This Looks Like in Practice
+
+{/* Two concrete walkthroughs, kept brief but specific.
+
+A bug report: issue comes in missing debug logs. Phase 1 catches it and prompts the reporter. Phase 2 finds a relevant troubleshooting doc. Phase 3 flags a potential duplicate from two months ago. The bot posts one comment with all three pieces of information. The maintainer reviews, confirms the duplicate, and closes with a link.
+
+A feature request: issue comes in for a capability that's partially on the roadmap. Phase 4a surfaces the roadmap item and a related ADR. The Enhancement Researcher creates a shadow issue and posts a context brief. The maintainer replies "research." The agent produces a synthesis with three approaches and trade-offs. The maintainer picks one and uses it to respond to the original issue.
+
+These should be based on real (or realistic) examples. */}
+
+## Closing
+
+{/* The triage bot is not about replacing the maintainer's judgement. It is about giving the maintainer better information, faster.
+
+Every design decision — silent mode, safety layers, the 4-round-trip boundary, the dashboard, the single consolidated comment — exists to keep the human in control while letting AI handle the searching, comparing, and summarising.
+
+Back-link to [Article 1](/en/articles/ai-assisted-open-source-maintenance) (principles) and [Article 2](/en/articles/ai-assisted-open-source-workflow) (workflow). Note that the triage bot's safety layers and escalation model are also concrete examples of observability for agentic systems — forward-link to the observability article when published. */}

--- a/src/content/articles/en/vibe-coding-an-allotment-app.mdx
+++ b/src/content/articles/en/vibe-coding-an-allotment-app.mdx
@@ -1,0 +1,55 @@
+---
+title: "Vibe Coding an Allotment App"
+description: "What happens when you let AI write an entire app from scratch — learnings from building Bonnie Wee Plot, a gardening tool for Scottish weather."
+publishedDate: 2026-03-10
+tags: ["AI", "Software Development", "Vibe Coding"]
+draft: true
+---
+
+{/* Standalone article, no series. Contrasts with the disciplined AI usage in the t4l series — this is the other end of the spectrum. */}
+
+{/* Tone: personal, honest, slightly humorous (the project has that tone — "growing anything in Scottish weather is already a form of extreme sport"). Not a tutorial, not a pitch. A reflection on the experience. */}
+
+## Why This Exists
+
+{/* The origin story, but lead with the gap between the original need and what got built — tease the "different skill required" insight.
+
+I wanted to track when to plant potatoes. What I ended up with is a Next.js 16 app with React 19, TypeScript, Tailwind, Supabase cloud sync, Clerk authentication, a PWA with offline support, an AI garden advisor called Aitor, a compost tracker, QR code data sharing, 192 plants in the database, and deployment to both Vercel and GitHub Pages.
+
+For an allotment app. Built because I needed to remember which bed had the broad beans last year.
+
+The entire thing was vibe-coded: every line written by Claude through VS Code agent mode and Claude Code CLI. I steered, corrected course, and decided what features mattered. The AI did the building. That's vibe coding as I define it here — letting AI do the heavy lifting on implementation while the human steers direction.
+
+This is the opposite end of the spectrum from how I use AI in teams-for-linux, where strict guardrails and review discipline keep everything controlled. Here, the guardrails were loose because the stakes were low: make it work, make it useful, and if it breaks, I'm the only user who cares. But loose guardrails taught me things that strict guardrails don't. */}
+
+## Where It Worked
+
+{/* Interleave wins and their limits for each area rather than separating "what worked" from "what didn't."
+
+Speed and scope creep: from idea to deployed app in a fraction of the time it would take to build manually. For a personal project where "good enough" is the bar, this is the biggest win. But AI will happily build whatever you ask for, and it will suggest more. The feature list kept growing because saying yes was free. 192 plants, multiple deployment targets, cloud sync, PWA, QR sharing — for a tool to track my broad beans. The AI Automation Trap in microcosm: the cost of building dropped to zero, but the cost of maintaining didn't.
+
+Exploration and over-engineering: AI is genuinely good at suggesting features and approaches you might not think of. The compost tracker, the seasonal phase detection, the QR code sharing — these emerged from the conversation rather than being planned. Some of them are useful. Some of them are engineering for the sake of engineering. The line between "creative exploration" and "unnecessary complexity" is hard to see when building is free.
+
+Boring plumbing and consistency: authentication, cloud sync, responsive layouts, PWA configuration — this is the work that kills motivation on personal projects, and AI handles it without complaint. But across a large codebase, AI drifts in patterns and conventions. Without a CLAUDE.md equivalent to enforce consistency, the code has areas where the style shifts noticeably. The plumbing works, but the seams show.
+
+Testing: AI generates tests quickly, but they tend to test the implementation rather than the behaviour. Getting meaningful coverage — tests that would actually catch regressions — requires active steering. Left to its own devices, the AI writes tests that pass but wouldn't catch the bugs you care about. */}
+
+## The "Too Creative / Too Lazy" Spectrum
+
+{/* This deserves its own short section because it captures something real about working with AI.
+
+Sometimes the AI over-architects a solution when a simple approach would do — three layers of abstraction for something that should be a function. Other times it takes shortcuts that create technical debt — hardcoded values, skipped edge cases, patterns that work now but won't scale.
+
+Guiding it requires knowing what good looks like. You need to recognise when the AI is being too clever and when it's being too lazy. That means vibe coding is not "no coding skill required." It's "different coding skill required." The skill shifts from writing code to evaluating code, from implementation to judgement.
+
+This is the same insight from the t4l articles, arrived at from the opposite direction. Whether you're maintaining a serious open-source project with strict guardrails or building a personal tool with loose ones, the human value is in the deciding, not the building. */}
+
+## Would I Do It Again?
+
+{/* Yes, for personal projects where "useful enough" is the bar.
+
+The app works. It's deployed at bonnie-wee-plot.vercel.app. It helps with allotment management. It took a fraction of the time it would have taken to build by hand. For a project that might have never existed otherwise, that's a clear win.
+
+The learnings about scope discipline, consistency drift, and the judgement skill translate to any AI-assisted development. The vibe coding experience reinforced the principles I follow in more disciplined contexts — just from the other end of the spectrum. With teams-for-linux, the guardrails exist because thousands of users depend on it. With Bonnie Wee Plot, the guardrails were loose because the stakes were low. Both approaches are valid. The difference is risk tolerance, and risk tolerance should drive how much structure you put around AI usage.
+
+If others find the app useful — good, that's why it's open source and deployed. But the primary audience was always me, and for that purpose, vibe coding delivered. */}


### PR DESCRIPTION
Expands the content pipeline plan with the full article backlog discussed.

- Observability series: marks Article 1 as published, adds detail for Article 2 (Observability for Agentic Systems) with the triage bot as a real-world example
- Teams for Linux series: restructures into a three-article arc (principles → workflow → triage bot tooling)
- Adds Bonnie Wee Plot vibe coding article
- Moves local-brain and ai-model-advisor from vague mentions to proper backlog entries with article angles

No code changes.