### PR TITLE
fix(deps): update vite to resolve GHSA-p9ff-h696-f583

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,14 +26,14 @@
       }
     },
     "node_modules/@astrojs/check": {
-      "version": "0.9.6",
-      "resolved": "https://registry.npmjs.org/@astrojs/check/-/check-0.9.6.tgz",
-      "integrity": "sha512-jlaEu5SxvSgmfGIFfNgcn5/f+29H61NJzEMfAZ82Xopr4XBchXB1GVlcJsE+elUlsYSbXlptZLX+JMG3b/wZEA==",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@astrojs/check/-/check-0.9.8.tgz",
+      "integrity": "sha512-LDng8446QLS5ToKjRHd3bgUdirvemVVExV7nRyJfW2wV36xuv7vDxwy5NWN9zqeSEDgg0Tv84sP+T3yEq+Zlkw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@astrojs/language-server": "^2.16.1",
-        "chokidar": "^4.0.1",
+        "@astrojs/language-server": "^2.16.5",
+        "chokidar": "^4.0.3",
         "kleur": "^4.1.5",
         "yargs": "^17.7.2"
       },
@@ -11929,9 +11929,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-      "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",


### PR DESCRIPTION
## Summary

Updates vite to resolve high-severity vulnerabilities including GHSA-p9ff-h696-f583 (arbitrary file read via dev server WebSocket) and GHSA-4w7w-66w2-5vf9 (path traversal in optimized deps .map handling).

Before: 10 vulnerabilities (1 high, 5 moderate, 4 low)
After: 9 vulnerabilities (0 high, 5 moderate, 4 low) — remaining are unrelated to vite and require breaking changes to fix

## Test plan

- 2/3 test suites pass; 1 pre-existing failure (requires `npm run build` first, same on main)
- npm audit shows 0 high/critical vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)