### PR TITLE
docs: refresh routing, paths, and commands after Astro 6 + Phase 4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,9 +5,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Commands
 
 ```bash
-npm run dev      # Start development server
-npm run build    # Build for production
-npm run preview  # Preview production build
+npm run dev          # Start development server
+npm run build        # Build for production (output in ./dist)
+npm run preview      # Preview production build
+npm run lint         # ESLint across the repo
+npm run typecheck    # Astro + TypeScript check
+npm test             # Run Vitest suite (build tests require ./dist to exist)
+npm run check-links  # Validate internal links in ./dist (run after build)
 ```
 
 ## Architecture
@@ -18,11 +22,11 @@ This is a multilingual Astro static site with three supported locales: English (
 
 The i18n system centres on `src/i18n/translations.ts`, which exports the `useTranslations(lang)` function used throughout components. Every UI string is keyed in this file across all three locales. The `getLangFromUrl()` and `getLocalizedPath()` helpers handle routing between language versions.
 
-Page routes mirror each locale directory: `src/pages/en/index.astro`, `src/pages/es/index.astro`, etc. The root `src/pages/index.astro` redirects to the default locale (`/en/`).
+Pages are defined once under `src/pages/[lang]/…` as dynamic routes that use `getStaticPaths()` to emit `/en/`, `/es/`, and `/cat/` variants (see `docs/plans/2026-02-15-phase4-security-maintainability-design.md` for the deduplication rationale). The root `src/pages/index.astro` redirects to the default locale (`/en/`), and `src/pages/404.astro` is the shared 404.
 
 ### Content
 
-Static data (projects, links) lives in TypeScript files under `src/data/` with inline translations per object. Articles use Astro Content Collections in `src/content/articles/{locale}/` with MDX format. The schema is defined in `src/content/config.ts`.
+Static data (projects, links, uses, health, fun) lives in TypeScript files under `src/data/` with inline translations per object. Articles use Astro Content Collections in `src/content/articles/{locale}/` with MDX format. The schema is defined in `src/content.config.ts` (Astro 6's top-level content config location).
 
 Articles follow POSSE (Publish Own Site, Syndicate Elsewhere) strategy per ADR 001 in `docs/adr/`. Frontmatter includes `originalUrl` and `originalPlatform` to link back to syndicated copies on Medium/Dev.to.
 
@@ -30,9 +34,13 @@ Articles follow POSSE (Publish Own Site, Syndicate Elsewhere) strategy per ADR 0
 
 `src/layouts/Layout.astro` is the base layout with navigation, language switcher, and footer. `src/layouts/ArticleLayout.astro` handles article pages. Components in `src/components/` are shared across locales.
 
+### Testing & CI
+
+Vitest tests live under `tests/` (unit tests for i18n and reading-time, plus `tests/build/output.test.ts` which reads files from `./dist` and is skipped unless a build has been produced). The link checker in `scripts/check-links.js` walks built HTML in `./dist/` and verifies internal hrefs resolve to real files. CI (`.github/workflows/ci.yml`) runs lint, typecheck, build, tests, link check, and Lighthouse CI on pushes to `main`/`develop` and PRs to `main`.
+
 ### Deployment
 
-GitHub Actions workflow (`.github/workflows/gh-pages.yml`) builds and deploys to GitHub Pages on push to main. Output goes to `./dist`.
+The deploy workflow (`.github/workflows/gh-pages.yml`) runs after a successful CI on `main` (and on a daily cron) to build and publish to GitHub Pages. Output goes to `./dist`. A `vercel.json` also exists as a fallback/mirror configuration.
 
 ## Repo Butler
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,11 +21,15 @@ This site is built with [Astro](https://astro.build/). To run it locally:
 
 ## Available Commands
 
-| Command           | Action                                      |
-|-------------------|---------------------------------------------|
-| `npm run dev`     | Start development server                    |
-| `npm run build`   | Build for production (output in `./dist`)   |
-| `npm run preview` | Preview production build locally            |
+| Command               | Action                                                    |
+|-----------------------|-----------------------------------------------------------|
+| `npm run dev`         | Start development server                                  |
+| `npm run build`       | Build for production (output in `./dist`)                 |
+| `npm run preview`     | Preview production build locally                          |
+| `npm run lint`        | Run ESLint across the repo                                |
+| `npm run typecheck`   | Run Astro + TypeScript checks                             |
+| `npm test`            | Run Vitest suite (build tests require `./dist` to exist)  |
+| `npm run check-links` | Verify internal links in `./dist` (run after `build`)     |
 
 ## Adding Articles
 
@@ -57,13 +61,22 @@ Articles use Astro Content Collections with MDX format. To add a new article:
 
 ```
 src/
-├── pages/          # File-based routing with locale prefixes (/en/, /es/, /cat/)
-├── layouts/        # Layout.astro (base) and ArticleLayout.astro
-├── components/     # Shared components (Hero, ProjectCard, etc.)
-├── content/        # Content collections (articles in MDX)
-├── data/           # Static data (projects, links, fun quiz)
-├── i18n/           # Translation system
-└── styles/         # Global CSS design tokens
+├── pages/
+│   ├── [lang]/         # Dynamic locale routes (emit /en/, /es/, /cat/ via getStaticPaths)
+│   ├── 404.astro       # Shared 404 page
+│   └── index.astro     # Redirects to the default locale
+├── layouts/            # Layout.astro (base) and ArticleLayout.astro
+├── components/         # Shared components (Hero, ProjectCard, Health*, etc.)
+├── content/articles/   # MDX articles per locale (en/, es/, cat/)
+├── content.config.ts   # Astro content collection schema
+├── data/               # Static data (projects, links, uses, health, fun quiz)
+├── i18n/               # Translation system
+├── utils/              # Small helpers (reading-time, …)
+└── styles/             # Global CSS design tokens
+
+tests/                  # Vitest unit and build-output tests
+scripts/                # Build-time scripts (e.g. check-links.js)
+docs/                   # ADRs and design/implementation plans
 ```
 
 ## Multi-language Support

--- a/docs/adr/001-article-translation-publishing-strategy.md
+++ b/docs/adr/001-article-translation-publishing-strategy.md
@@ -130,11 +130,11 @@ Workflow:
 
 The following components were created:
 
-- `src/content/config.ts` - Content collection schema
+- `src/content.config.ts` - Content collection schema (moved from `src/content/config.ts` in the Astro 6 upgrade)
 - `src/layouts/ArticleLayout.astro` - Article page layout with language switcher
 - `src/components/ArticleCard.astro` - Article list card component
-- `src/pages/[locale]/articles/[...slug].astro` - Dynamic article routes
-- Updated `src/pages/[locale]/writing.astro` - Shows local articles + external platform links
+- `src/pages/[lang]/articles/[...slug].astro` - Dynamic article routes
+- Updated `src/pages/[lang]/writing.astro` - Shows local articles + external platform links
 
 ## References
 


### PR DESCRIPTION
CLAUDE.md, CONTRIBUTING.md, and ADR 001 still described the pre-Phase 4
layout (per-locale page files) and the pre-Astro 6 content config path
(`src/content/config.ts`). Update all three to reflect the current
`src/pages/[lang]/` dynamic routes and `src/content.config.ts`, and
document the full command surface (lint, typecheck, test, check-links)
that CI already runs.