### PR TITLE
fix(security): patch postcss CVE and reading-time sanitization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6367,9 +6367,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
       "funding": [
         {
           "type": "opencollective",

--- a/src/utils/reading-time.ts
+++ b/src/utils/reading-time.ts
@@ -1,7 +1,13 @@
 const WORDS_PER_MINUTE = 200;
 
 export function getReadingTime(content: string): number {
-  const text = content.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim();
+  let stripped = content;
+  let previous: string;
+  do {
+    previous = stripped;
+    stripped = stripped.replace(/<[^>]*>/g, '');
+  } while (stripped !== previous);
+  const text = stripped.replace(/\s+/g, ' ').trim();
   const wordCount = text.split(' ').filter(Boolean).length;
   return Math.max(1, Math.ceil(wordCount / WORDS_PER_MINUTE));
 }

--- a/src/utils/reading-time.ts
+++ b/src/utils/reading-time.ts
@@ -5,7 +5,7 @@ export function getReadingTime(content: string): number {
   let previous: string;
   do {
     previous = stripped;
-    stripped = stripped.replace(/<[^>]*>/g, '');
+    stripped = stripped.replace(/<[^>]*>/g, ' ');
   } while (stripped !== previous);
   const text = stripped.replace(/\s+/g, ' ').trim();
   const wordCount = text.split(' ').filter(Boolean).length;


### PR DESCRIPTION
## Summary

Addresses two open security alerts:

### Dependabot #54: postcss XSS via Unescaped `</style>` (GHSA-qx2v-qp2m-jg93, moderate)
Bumped postcss from 8.5.x (<8.5.10) to 8.5.13 via `npm audit fix`. Only `package-lock.json` changed; postcss is a transitive dep of `astro` -> `vite` and `eslint-plugin-astro`.

### Code scanning #1: js/incomplete-multi-character-sanitization (high)
`src/utils/reading-time.ts:4` stripped HTML tags with a single `String.replace(/<[^>]*>/g, '')` pass. Inputs like `<<scr>ipt>` survived the filter because removing the inner `<scr>` left a fresh `<ipt>` tag behind. Fixed by looping the replace until the output is stable, so any nested or overlapping tag fragments are fully stripped.

## Test plan

- [x] `npm test` (vitest) — 57/57 pass
- [x] `npm run lint` — clean
- [x] `npm audit` — postcss advisory cleared (remaining `yaml` advisories are unrelated, gated behind a breaking `@astrojs/check` downgrade)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>