### PR TITLE
docs: roadmap entry for global CLAUDE.md review

### DIFF
--- a/docs/plans/2026-05-12-claude-md-review.md
+++ b/docs/plans/2026-05-12-claude-md-review.md
@@ -1,0 +1,61 @@
+# CLAUDE.md review and reconciliation
+
+## Status
+
+Roadmap entry only. Run `/plan` against this in a fresh clean session, then execute. Do not begin the review work in this session.
+
+## Why this exists
+
+The user's global `CLAUDE.md` at `~/.claude-home/CLAUDE.md` (and its mirror at `~/.claude/CLAUDE.md`) has grown by accretion across many sessions. Each rule was added in a context where it made sense, but the file has not been read end-to-end as a coherent ruleset. A new rule landed on 2026-05-12 ("after opening a PR/MR, immediately run `/address-pr-comments` without being asked") which surfaces a likely conflict with an older rule ("after opening a PR, anything past that point requires explicit user confirmation per MR"). Both can be read consistently if "anything past that point" is interpreted narrowly as "merging," but the surface reading is contradictory and a future session reading the file fresh may apply them inconsistently.
+
+The expectation is that there are more contradictions, duplications, and ambiguities like this hiding in the file. A systematic pass is warranted.
+
+## Identified conflicts (starter list, not exhaustive)
+
+The 2026-05-12 review should at minimum address the following. These are the ones already noticed during the session that produced this roadmap entry; the actual review should expand and verify.
+
+The no-autonomous-merge rule on line 2 says "anything past [opening a PR] requires explicit user confirmation per MR". The new rule on line 7 says "after opening a PR/MR, immediately run `/address-pr-comments` without being asked." These are reconcilable in spirit (the address-pr-comments skill explicitly stops before merging) but the wording is in surface conflict. A reader applying line 2 literally would refuse to run address-pr-comments without being asked. The fix is probably to rewrite line 2 so "anything past that point" specifies merge and ship actions rather than all post-PR actions.
+
+There may also be redundancy between line 5 ("when addressing PR review comments, always reply to each individual comment") and line 7 (the new rule that triggers the address-pr-comments skill, which itself enforces per-comment replies). Line 5 may become subsumed once line 7 takes effect.
+
+## Approach
+
+In the new session:
+
+Run `/plan` first to formalise the implementation plan. The plan should account for the constraints below.
+
+Use the `/claude-md-management:claude-md-improver` skill as the primary tool. It audits CLAUDE.md files against templates and outputs a quality report before applying changes.
+
+Consider dispatching parallel agents (per the `superpowers:dispatching-parallel-agents` skill) for independent slices of the review. Candidate slices: conflict detection, redundancy detection, vague-language detection, and external-skill-name verification (do all the slash commands the file mentions still exist).
+
+Delegate to ollama where it fits. Use the `delegate-to-ollama` skill for tasks like "summarise this paragraph", "extract rules from this section", "rewrite this rule with the same meaning but no ambiguity", and similar closed-form text work. Prefer MLX-backed models on this hardware; they're more performant on Apple Silicon than GGUF-quantised models of the same size. The user's installed model list should be checked at session start and the prose/reasoning tier mappings adjusted if MLX variants are available.
+
+Learn from each delegation. When a delegation produces a regression or surprising failure mode, open an issue in `IsmaelMartinez/delegate-to-ollama` with the input, the failure mode, the model used, and a suggested directive-rule mitigation. See issue #107 there for the format already in use.
+
+The review itself must not be destructive. Read the file, propose changes, get user sign-off before any write. Use `Edit` (not `Write`) for changes so the diff is small and reviewable. Commit changes in a dedicated branch with a PR.
+
+## Scope
+
+In scope: `~/.claude-home/CLAUDE.md` (and the `~/.claude/CLAUDE.md` mirror if they differ).
+
+Out of scope: project-specific CLAUDE.md files at `<repo>/CLAUDE.md`. Those are owned by their respective repos and should be reviewed separately.
+
+## Success criteria
+
+The output of the review should be:
+
+A short audit report identifying every conflict, redundancy, and ambiguity found, with line numbers.
+
+A proposed reconciled version of `CLAUDE.md` that resolves them. The file should be no longer than the current version, and ideally shorter once duplications are merged.
+
+Per-conflict commentary explaining the reconciliation choice so the user can override individual decisions.
+
+A list of any slash-command names referenced in the file that no longer resolve to an installed skill.
+
+No changes applied until the user approves the proposed version.
+
+## Notes for the executor
+
+The file currently has rules expressed in multiple formats: bullet points, `<tag>` blocks, and prose paragraphs. Preserve that mix unless asked to normalise. The `<avoid_excessive_markdown_and_bullet_points>` block at lines 8-16 is itself an example of the tag-block style and should be respected when proposing rewrites.
+
+The user has expressed preferences in this session that should also be reflected in the reconciled file if not already: prefer parallel tool calls when independent, delegate to local models where appropriate, write in flowing prose rather than bullet-heavy lists.

--- a/src/content/articles/cat/ai-assisted-open-source-cadences.mdx
+++ b/src/content/articles/cat/ai-assisted-open-source-cadences.mdx
@@ -1,0 +1,37 @@
+---
+title: "Codi obert assistit per IA: cadències i senyals"
+description: "Què canvia quan executes diversos projectes a diferents velocitats: vida llarga, estacional, efímer, reactiu. La disciplina és la mateixa; les restriccions s'han de doblegar amb el cicle de vida, i les senyals esdevenen la veritable limitació."
+publishedDate: 2026-03-18
+tags: ["IA", "Codi Obert", "Desenvolupament de Software", "Teams for Linux"]
+draft: true
+---
+
+## D'un projecte a diversos
+
+El [primer article](/cat/articles/ai-assisted-open-source-maintenance) va preguntar què canvia la IA en mantenir un projecte open source, a través de la lent d'un codi de 7 anys. El [segon](/cat/articles/ai-assisted-open-source-workflow) va ser el flux de treball que el manté en marxa. Tots dos es van quedar dins d'una sola cadència de vida llarga. Aquest surt d'aquell marc: l'assistència d'IA fa que executar diversos projectes en paral·lel, a diferents velocitats, sigui realment factible, i això canvia el que el flux de treball ha de gestionar.
+
+## Quatre cadències
+
+teams-for-linux és el de vida llarga: set anys d'història, centenars de milers d'usuaris actius, totes les restriccions.
+
+bonnie-wee-plot és estacional, una app escocesa d'hort on les funcionalitats que importen al març (finestres de sembra) són diferents de les que importen a l'agost (collita, vigilància de míldiu). El codi creix en capítols, amb l'any hortícola dient-li què construir a continuació.
+
+votescot és efímer, una brúixola de vot open source construïda per a les eleccions del Parlament Escocès del 2026. La finestra de rellevància és estreta; el codi ha de ser sòlid durant tota la seva durada, però el cicle de vida té un final incorporat.
+
+wifisentinel és reactiu, construït ràpidament perquè una situació específica el necessitava (un Airbnb sospitós a Amsterdam on volia saber què hi havia realment a la xarxa). El que va començar com una eina puntual va créixer fins a esdevenir un kit complet un cop el problema original es va resoldre.
+
+## Ajusta les restriccions a la cadència
+
+Les restriccions completes de l'Article 2 són adequades per a un projecte de 7 anys i equivocades per a una brúixola de vot d'un mes. Procés màxim en un codi efímer és sobrecàrrega disfressada de rigor. Però "menys restriccions" no és "cap restricció": votescot continua tenint CI, linting i revisió manual a cada diff. Els estàndards que protegeixen els usuaris d'un comportament trencat s'apliquen a cada cadència; els que protegeixen un codi de vida llarga contra la confusió del jo futur no s'apliquen quan no hi ha jo futur a confondre. La disciplina és ajustar les restriccions al cicle de vida, no aplicar cerimònia màxima a tot arreu.
+
+## L'Estrella de la Mort encara és real
+
+Els bugs s'amaguen en la complexitat. La IA no deroga aquesta regla; la fa més urgent. Quan el cost d'escriure codi baixa, només baixa el cost d'escriure, no el de llegir, depurar ni retirar. La temptació de continuar afegint és més gran que mai, cosa que vol dir que dir "no, això és una Estrella de la Mort" importa més, no menys. A cada cadència es manifesta de forma diferent. "Deu anys de manteniment" en un projecte de vida llarga, "massa astut per a sis setmanes" en un d'efímer. Però és el mateix recordatori.
+
+## Les senyals són la limitació
+
+Amb assistència d'IA i restriccions de la mida adequada, el coll d'ampolla es desplaça. Ja no és quant codi pots llançar; això està resolt. És si pots detectar, a temps, quan alguna cosa ha anat malament. Els tests són senyal. CI és senyal. La revisió manual és senyal. Els ADRs són senyal sobre decisions. Les restriccions existeixen per produir senyal; el flux de treball existeix per actuar-hi. El viatge és el mateix que qualsevol mantenidor ha conegut sempre: construir confiança amb dades, afegir solidesa a mesura que avances, simplificar o treure el que deixa de guanyar-se el seu lloc. La IA accelera els cicles, així que la qualitat de la senyal ha de seguir-los el ritme. Estalviar en això és el que converteix la productivitat assistida per IA en un caos amplificat per IA.
+
+## Reflexió final
+
+Mateixa disciplina, cicles de vida molt diferents. Les restriccions es doblen, la cadència dicta la forma, i les senyals esdevenen allò que optimitzes. El viatge no s'ha acabat. La taxonomia de cadències necessitarà noves categories, i l'Estrella de la Mort seguirà sent una temptació. El que canvia és com de ràpid pots moure't pels cicles, i si la qualitat de la teva senyal segueix el ritme de la teva velocitat.

--- a/src/content/articles/cat/ai-assisted-open-source-maintenance.mdx
+++ b/src/content/articles/cat/ai-assisted-open-source-maintenance.mdx
@@ -62,15 +62,13 @@ Amb eines d'IA, puc mantenir el ritme amb pegats de seguretat, actualitzacions d
 
 L'alternativa al manteniment assistit per IA no és "escriure-ho tot a mà." És "deixar que els issues s'acumulin i eventualment abandonar el projecte." Per a mantenidors de codi obert en solitari, la IA és una eina de sostenibilitat, no una drecera.
 
-## Els marcadors visibles
+## Treballar a la vista
 
-Cada commit assistit per IA al repositori porta una etiqueta `Co-authored-by`. Això és transparència, no confessió.
+Cada commit assistit per IA al repositori porta una etiqueta `Co-authored-by`. L'arxiu CLAUDE.md està inclòs al repositori on qualsevol pot llegir-lo. Això no és fer una declaració — és aprendre.
 
-L'arxiu CLAUDE.md està inclòs al repositori on qualsevol pot llegir-lo. Podria amagar tot això fàcilment. Treure les etiquetes de coautoria, eliminar l'arxiu de configuració, i ningú ho sabria. Vaig triar no fer-ho perquè ser obert sobre les eines és el correcte.
+Vull entendre què funciona. Quins tipus de canvis assistits per IA són acceptats sense problemes per la comunitat? Quins generen fricció? Canvia la participació visible de la IA com la gent interactua amb el projecte? Són preguntes obertes, i l'única forma de respondre-les és ser obert sobre el procés.
 
-La ironia és que amagar l'ús d'IA és trivialment fàcil i gairebé segur que està generalitzat. Els projectes que són transparents al respecte són els que reben escrutini, mentre que els projectes que ho amaguen no afronten cap pregunta. Aquesta estructura d'incentius està al revés.
-
-La transparència sobre l'ús d'IA s'hauria de normalitzar, no penalitzar. La conversa hauria de ser sobre resultats — funciona el programari, es manté, s'atén bé als usuaris? — no sobre quines eines va fer servir el mantenidor per arribar-hi.
+Si altres mantenidors trien mostrar o amagar el seu ús d'IA és assumpte seu. No m'interessa aquest debat. El que m'interessa és fer un experiment honest: mantenir un projecte obertament amb eines d'IA, veure quina és realment la resposta de la comunitat, i compartir el que aprengui.
 
 ## Reflexió final
 

--- a/src/content/articles/cat/ai-assisted-open-source-maintenance.mdx
+++ b/src/content/articles/cat/ai-assisted-open-source-maintenance.mdx
@@ -8,7 +8,7 @@ draft: true
 
 ## El projecte és anterior a les eines
 
-teams-for-linux va començar el 2018. Això és més de cinc anys abans que existís qualsevol eina de programació amb IA. Vaig construir un wrapper Electron per a Microsoft Teams perquè Microsoft va deixar de donar suport oficial a Linux i milers de desenvolupadors necessitaven un client que funcionés. El projecte va créixer orgànicament fins a superar les 4.400 estrelles, 315 forks i 30 contribuïdors al llarg dels anys.
+teams-for-linux va començar el 2018, anys abans que les eines de programació amb IA es generalitzessin. Vaig construir un wrapper Electron per a Microsoft Teams perquè no existia un client oficial per a Linux en aquell moment — Microsoft no en llançaria un fins a finals de 2019, i quan finalment el van retirar el 2023, teams-for-linux es va convertir en l'opció de facto. El projecte va créixer orgànicament fins a superar les 4.500 estrelles, 320 forks i desenes de contribuïdors al llarg dels anys.
 
 L'adopció d'IA va arribar molt després. És una elecció d'eines que vaig fer per mantenir el ritme amb les demandes de mantenir un projecte d'aquesta mida, no la història d'origen. La cronologia importa perquè a vegades la gent mira un repositori, veu senyals d'eines d'IA i assumeix que tot va ser generat. No va ser així. El projecte té set anys d'història, comunitat i decisions arquitectòniques guanyades amb esforç al darrere.
 

--- a/src/content/articles/cat/ai-assisted-open-source-maintenance.mdx
+++ b/src/content/articles/cat/ai-assisted-open-source-maintenance.mdx
@@ -3,7 +3,7 @@ title: "Codi obert assistit per IA: què canvia i què no"
 description: "Com les eines d'IA encaixen en el manteniment d'un projecte open source de 7 anys — què accelera, què no pot reemplaçar i per què existeix l'arxiu CLAUDE.md."
 publishedDate: 2026-03-03
 tags: ["IA", "Codi Obert", "Desenvolupament de Software", "Teams for Linux"]
-draft: false
+draft: true
 ---
 
 ## El projecte és anterior a les eines

--- a/src/content/articles/cat/ai-assisted-open-source-maintenance.mdx
+++ b/src/content/articles/cat/ai-assisted-open-source-maintenance.mdx
@@ -3,7 +3,7 @@ title: "Codi obert assistit per IA: què canvia i què no"
 description: "Com les eines d'IA encaixen en el manteniment d'un projecte open source de 7 anys — què accelera, què no pot reemplaçar i per què existeix l'arxiu CLAUDE.md."
 publishedDate: 2026-03-03
 tags: ["IA", "Codi Obert", "Desenvolupament de Software", "Teams for Linux"]
-draft: true
+draft: false
 ---
 
 ## El projecte és anterior a les eines
@@ -19,6 +19,8 @@ Quan la gent va veure l'arxiu CLAUDE.md al repositori, alguns van assumir que si
 CLAUDE.md és un arxiu de configuració, semblant a `.editorconfig` o `tsconfig.json`. Li diu a l'eina d'IA com comportar-se en aquest codi específic. Documenta decisions arquitectòniques, límits de mòduls i invariants crítics — com el requisit d'inicialització de `trayIconRenderer`/`mqttStatusMonitor` que s'ha trencat accidentalment diverses vegades per contribuïdors que no coneixien la dependència.
 
 L'arxiu codifica coneixement específic del projecte perquè l'eina d'IA respecti els patrons existents en lloc d'inventar-ne de nous. Cada codi té regles no escrites. CLAUDE.md les fa explícites. No és un senyal d'autoria per IA. És un senyal de disciplina amb la IA.
+
+A [l'article complementari sobre el flux de treball real](/cat/articles/ai-assisted-open-source-workflow) aprofundeixo en com aquest arxiu dona forma a cada interacció — des d'investigacions fins a actualitzacions de dependències i implementació de funcionalitats.
 
 ## Què accelera realment la IA
 
@@ -45,6 +47,8 @@ Les decisions arquitectòniques estan en la mateixa categoria. Quan refactoritza
 El criteri de llançament és més matisat del que sembla. Està llesta aquesta build? Hauria d'acumular més correccions primer? És la correcció de Wayland prou estable per publicar, o necessita una altra setmana de proves? Aquestes decisions requereixen context al qual cap eina té accés.
 
 Entendre els canvis upstream és un desafiament constant. La webapp de Teams canvia sense avís, i la programació defensiva contra aquests canvis requereix un coneixement profund del domini sobre el que Microsoft probablement farà i com evoluciona la seva plataforma. La IA no sap què va publicar Microsoft dimarts passat.
+
+Alguns problemes simplement no tenen solució, independentment de les eines. Quan Microsoft canvia la seva webapp de maneres que trenquen clients de tercers, cap quantitat de programació assistida per IA pot produir una solució alternativa que no existeix. El mantenidor ha de reconèixer quan un problema no té bona solució, comunicar-ho honestament als usuaris i seguir endavant. La IA seguirà intentant generar correccions per a coses que no es poden corregir.
 
 I després hi ha dir no a les peticions de funcionalitats. Això és potser la part més difícil de mantenir un projecte popular, i és completament una habilitat humana.
 
@@ -75,3 +79,5 @@ La pregunta interessant no és "ha escrit la IA aquest codi?"
 És si el projecte funciona, si es manté i si els usuaris estan ben atesos. Per aquestes mesures, les eines d'IA estan fent exactament el que haurien — mantenir viu i receptiu un projecte útil quan l'alternativa és la decadència lenta.
 
 A [La trampa de l'automatització amb IA](/cat/articles/the-ai-automation-trap) vaig escriure sobre com la IA va eliminar la restricció de construir però no va eliminar la restricció de decidir. Aquest projecte és l'exemple viscut. La IA s'encarrega de construir. El decidir, el mantenir i el preocupar-se pels usuaris — això segueix sent completament humà. I sempre ho serà.
+
+Si vols veure com funciona això en el dia a dia — el flux de treball específic, les eines, els controls de qualitat — llegeix [Codi obert assistit per IA: el flux de treball](/cat/articles/ai-assisted-open-source-workflow).

--- a/src/content/articles/cat/ai-assisted-open-source-maintenance.mdx
+++ b/src/content/articles/cat/ai-assisted-open-source-maintenance.mdx
@@ -30,7 +30,7 @@ La implementació de funcionalitats ben enteses és el més obvi. Un cop he deci
 
 Les actualitzacions de dependències i les respostes a pegats de seguretat són on l'estalvi de temps realment s'acumula. L'ecosistema npm envia avisos de seguretat diverses vegades per setmana. Cadascun necessita avaluació, pegat, proves i llançament. Sense eines, això sol pot consumir la majoria de les hores disponibles d'un mantenidor.
 
-Explorar APIs poc familiars és una altra àrea on la IA destaca. La superfície d'API d'Electron és enorme, Wayland té les seves pròpies peculiaritats, i Trusted Types va introduir un conjunt completament nou de restriccions. Tenir una eina que pot mostrar ràpidament documentació rellevant i patrons d'ús redueix significativament el temps d'exploració.
+Explorar APIs poc familiars és una altra àrea on la IA destaca. La superfície d'API d'Electron és enorme, Wayland té les seves pròpies peculiaritats, i Linux és una caixa plena de sorpreses. Tenir una eina que pot mostrar ràpidament documentació rellevant i patrons d'ús redueix significativament el temps d'exploració.
 
 També vaig construir un bot de triatge amb Gemini per a issues de GitHub. Quan un projecte rep centenars d'issues, classificar el senyal del soroll manualment no és sostenible. El bot s'encarrega de la categorització inicial perquè jo pugui centrar-me en els issues que realment necessiten atenció humana.
 

--- a/src/content/articles/cat/ai-assisted-open-source-maintenance.mdx
+++ b/src/content/articles/cat/ai-assisted-open-source-maintenance.mdx
@@ -8,7 +8,7 @@ draft: true
 
 ## El projecte és anterior a les eines
 
-teams-for-linux va començar el 2018, anys abans que les eines de programació amb IA es generalitzessin. Vaig construir un wrapper Electron per a Microsoft Teams perquè no existia un client oficial per a Linux en aquell moment — Microsoft no en llançaria un fins a finals de 2019, i quan finalment el van retirar el 2023, teams-for-linux es va convertir en l'opció de facto. El projecte va créixer orgànicament fins a superar les 4.500 estrelles, 320 forks i desenes de contribuïdors al llarg dels anys.
+teams-for-linux va començar el 2018, anys abans que les eines de programació amb IA es generalitzessin. Vaig construir un wrapper Electron per a Microsoft Teams perquè no existia un client oficial per a Linux en aquell moment — Microsoft no en llançaria un fins a finals de 2019, i quan finalment el van retirar a finals de 2022, teams-for-linux es va convertir en l'opció de facto. El projecte ha crescut orgànicament fins a superar les 4.600 estrelles, 330 forks i desenes de contribuïdors al llarg dels anys (xifres en el moment d'escriure).
 
 L'adopció d'IA va arribar molt després. És una elecció d'eines que vaig fer per mantenir el ritme amb les demandes de mantenir un projecte d'aquesta mida, no la història d'origen. La cronologia importa perquè a vegades la gent mira un repositori, veu senyals d'eines d'IA i assumeix que tot va ser generat. No va ser així. El projecte té set anys d'història, comunitat i decisions arquitectòniques guanyades amb esforç al darrere.
 

--- a/src/content/articles/cat/ai-assisted-open-source-maintenance.mdx
+++ b/src/content/articles/cat/ai-assisted-open-source-maintenance.mdx
@@ -44,7 +44,7 @@ La gestió de la comunitat és feina completament humana. Quan els usuaris van c
 
 Les decisions arquitectòniques estan en la mateixa categoria. Quan refactoritzar versus quan pegar un pegat. On traçar els límits dels mòduls. Quanta compatibilitat cap enrere mantenir i quan trencar-la. Aquestes decisions donen forma al projecte durant anys i no es poden delegar a una eina que optimitza per a la tasca immediata.
 
-El criteri de llançament és més matisat del que sembla. Està llesta aquesta build? Hauria d'acumular més correccions primer? És la correcció de Wayland prou estable per publicar, o necessita una altra setmana de proves? Aquestes decisions requereixen context al qual cap eina té accés.
+El judici de llançament és més matisat del que sembla. Està llesta aquesta build? Hauria d'acumular més correccions primer? És la correcció de Wayland prou estable per publicar, o necessita una altra setmana de proves? Aquestes decisions requereixen context al qual cap eina té accés.
 
 Entendre els canvis upstream és un desafiament constant. La webapp de Teams canvia sense avís, i la programació defensiva contra aquests canvis requereix un coneixement profund del domini sobre el que Microsoft probablement farà i com evoluciona la seva plataforma. La IA no sap què va publicar Microsoft dimarts passat.
 

--- a/src/content/articles/cat/ai-assisted-open-source-maintenance.mdx
+++ b/src/content/articles/cat/ai-assisted-open-source-maintenance.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Codi obert assistit per IA: què canvia i què no"
-description: "Com les eines d'IA encaixen en el manteniment d'un projecte open source de 7 anys — què accelera, què no pot reemplaçar i per què existeix l'arxiu CLAUDE.md."
+description: "Com les eines d'IA encaixen en el manteniment d'un projecte open source de 7 anys: què accelera, què no pot reemplaçar i per què existeix l'arxiu CLAUDE.md."
 publishedDate: 2026-03-03
 tags: ["IA", "Codi Obert", "Desenvolupament de Software", "Teams for Linux"]
 draft: true
@@ -8,74 +8,30 @@ draft: true
 
 ## El projecte és anterior a les eines
 
-teams-for-linux va començar el 2018, anys abans que les eines de programació amb IA es generalitzessin. Vaig construir un wrapper Electron per a Microsoft Teams perquè no existia un client oficial per a Linux en aquell moment — Microsoft no en llançaria un fins a finals de 2019, i quan finalment el van retirar a finals de 2022, teams-for-linux es va convertir en l'opció de facto. El projecte ha crescut orgànicament fins a superar les 4.600 estrelles, 330 forks i desenes de contribuïdors al llarg dels anys (xifres en el moment d'escriure).
+Quan teams-for-linux va començar el 2018, les eines de programació amb IA no estaven al cap de ningú. Escrivíem el codi, escrivíem els tests, revisàvem la cobertura. El de sempre. El projecte va néixer per necessitat: Microsoft no tenia client per a Linux, i la seva web app no entregava notificacions, cosa que la feia força inútil com a app de xat.
 
-L'adopció d'IA va arribar molt després. És una elecció d'eines que vaig fer per mantenir el ritme amb les demandes de mantenir un projecte d'aquesta mida, no la història d'origen. La cronologia importa perquè a vegades la gent mira un repositori, veu senyals d'eines d'IA i assumeix que tot va ser generat. No va ser així. El projecte té set anys d'història, comunitat i decisions arquitectòniques guanyades amb esforç al darrere.
+A finals de 2019 Microsoft finalment va llançar una preview oficial per a Linux, així que el projecte va passar a segon pla i vaig aprofitar per olorar les roses. Això va durar fins a finals de 2022, quan Microsoft va retirar el client i molta gent va tornar aquí. Ara és 2026 i, en el moment d'escriure, el repositori té més de 4.000 estrelles i 300 forks.
 
-## Què és realment CLAUDE.md
+Per a un mantenidor en solitari en un projecte d'aquesta mida, la programació assistida per IA no és realment una qüestió de *si*. És una qüestió de *com fer-ho bé*. Aquest article exposa els principis; la resta de la sèrie és on ho treballo a la pràctica.
 
-Quan la gent va veure l'arxiu CLAUDE.md al repositori, alguns van assumir que significava que el projecte estava escrit per IA. Això és un malentès del que fa l'arxiu.
+## Què accelera la IA i què no
 
-CLAUDE.md és un arxiu de configuració, semblant a `.editorconfig` o `tsconfig.json`. Li diu a l'eina d'IA com comportar-se en aquest codi específic. Documenta decisions arquitectòniques, límits de mòduls i invariants crítics — com el requisit d'inicialització de `trayIconRenderer`/`mqttStatusMonitor` que s'ha trencat accidentalment diverses vegades per contribuïdors que no coneixien la dependència.
+La IA s'encarrega de la feina que d'altra manera cremaria un mantenidor en solitari: implementació de funcionalitats ben definides, actualitzacions de dependències i pegats de seguretat (que l'ecosistema npm produeix diverses vegades per setmana), explorar APIs poc familiars i triar issues a escala. La forma exacta segueix evolucionant. Continuo experimentant amb què delegar i com, amb eines com [repo-butler](https://github.com/IsmaelMartinez/repo-butler) vigilant la salut del portafoli al costat del propi projecte. L'objectiu no és només estalviar-me temps; és també estalviar temps als qui reporten, i fer millor l'eina per a tothom.
 
-L'arxiu codifica coneixement específic del projecte perquè l'eina d'IA respecti els patrons existents en lloc d'inventar-ne de nous. Cada codi té regles no escrites. CLAUDE.md les fa explícites. No és un senyal d'autoria per IA. És un senyal de disciplina amb la IA.
-
-A [l'article complementari sobre el flux de treball real](/cat/articles/ai-assisted-open-source-workflow) aprofundeixo en com aquest arxiu dona forma a cada interacció — des d'investigacions fins a actualitzacions de dependències i implementació de funcionalitats.
-
-## Què accelera realment la IA
-
-Les tasques que la IA gestiona bé són les que d'altra manera esgotarien un mantenidor en solitari.
-
-La implementació de funcionalitats ben enteses és el més obvi. Un cop he decidit què construir i com hauria de funcionar, la programació en si — la traducció mecànica d'intenció a codi — va més ràpid amb assistència d'IA. El boilerplate, l'scaffolding de tests i les actualitzacions de documentació cauen en la mateixa categoria. Són feina necessària, però no requereixen criteri creatiu.
-
-Les actualitzacions de dependències i les respostes a pegats de seguretat són on l'estalvi de temps realment s'acumula. L'ecosistema npm envia avisos de seguretat diverses vegades per setmana. Cadascun necessita avaluació, pegat, proves i llançament. Sense eines, això sol pot consumir la majoria de les hores disponibles d'un mantenidor.
-
-Explorar APIs poc familiars és una altra àrea on la IA destaca. La superfície d'API d'Electron és enorme, Wayland té les seves pròpies peculiaritats, i Linux és una caixa plena de sorpreses. Tenir una eina que pot mostrar ràpidament documentació rellevant i patrons d'ús redueix significativament el temps d'exploració.
-
-També vaig construir un bot de triatge amb Gemini per a issues de GitHub. Quan un projecte rep centenars d'issues, classificar el senyal del soroll manualment no és sostenible. El bot s'encarrega de la categorització inicial perquè jo pugui centrar-me en els issues que realment necessiten atenció humana.
-
-## Què no pot reemplaçar la IA
-
-La feina difícil de mantenir un projecte de codi obert no és escriure codi. Mai ho va ser.
-
-Decidir què construir i què no construir requereix entendre la direcció del projecte, les necessitats de la comunitat i les compensacions de cada addició. La IA no té opinió sobre això. Construirà feliçment el que li demanis, necessiti el projecte o no.
-
-La gestió de la comunitat és feina completament humana. Quan els usuaris van començar a queixar-se de la freqüència d'actualitzacions — la conversa de "calma amb les actualitzacions" — això requeria empatia, llegir l'ambient i fer un judici sobre la cadència de llançaments. Cap eina d'IA pot navegar això.
-
-Les decisions arquitectòniques estan en la mateixa categoria. Quan refactoritzar versus quan pegar un pegat. On traçar els límits dels mòduls. Quanta compatibilitat cap enrere mantenir i quan trencar-la. Aquestes decisions donen forma al projecte durant anys i no es poden delegar a una eina que optimitza per a la tasca immediata.
-
-El judici de llançament és més matisat del que sembla. Està llesta aquesta build? Hauria d'acumular més correccions primer? És la correcció de Wayland prou estable per publicar, o necessita una altra setmana de proves? Aquestes decisions requereixen context al qual cap eina té accés.
-
-Entendre els canvis upstream és un desafiament constant. La webapp de Teams canvia sense avís, i la programació defensiva contra aquests canvis requereix un coneixement profund del domini sobre el que Microsoft probablement farà i com evoluciona la seva plataforma. La IA no sap què va publicar Microsoft dimarts passat.
-
-Alguns problemes simplement no tenen solució, independentment de les eines. Quan Microsoft canvia la seva webapp de maneres que trenquen clients de tercers, cap quantitat de programació assistida per IA pot produir una solució alternativa que no existeix. El mantenidor ha de reconèixer quan un problema no té bona solució, comunicar-ho honestament als usuaris i seguir endavant. La IA seguirà intentant generar correccions per a coses que no es poden corregir.
-
-I després hi ha dir no a les peticions de funcionalitats. Això és potser la part més difícil de mantenir un projecte popular, i és completament una habilitat humana.
+El que la IA no pot tocar, almenys de moment, és la part que va pel gust. Decidir què construir (i què rebutjar), prioritzar dins la comunitat, entendre on haurien de seure les fronteres, jutjar quan una versió està a punt, saber quan un canvi upstream no té solució. Són decisions humanes. La IA generarà encantada arranjaments per a problemes que no tenen arranjament, i et dirà que té raó amb la mateixa convicció tant si la té com si no. Navegar això, i comunicar-se honestament amb els usuaris, és on viu la feina humana.
 
 ## La realitat del mantenidor en solitari
 
-teams-for-linux és un projecte d'un sol mantenidor amb milers d'usuaris actius. Aquesta proporció és el desafiament fonamental.
+teams-for-linux té molts contribuïdors, però en qualsevol moment donat només hi ha hagut un mantenidor. El relleu ha canviat de mans un parell de vegades, sobretot quan Microsoft va llançar el seu propi client per a Linux i el projecte va entrar en mode manteniment durant un temps. Avui el porto jo, al costat de centenars de milers d'usuaris actius.
 
-Sense eines d'IA, les matemàtiques no quadren. Respondre als issues porta més temps. Els llançaments passen amb menys freqüència. Els pegats de seguretat es queden a la cua. Eventualment el backlog creix més ràpid del que una persona pot abordar, i el projecte s'abandona. Això no és hipotètic — és el resultat per defecte per a projectes populars d'un sol mantenidor.
+Aquesta proporció és el repte principal. Fins i tot amb eines d'IA, mantenir-se al dia amb issues, PRs, llançaments i pegats de seguretat és una tasca diària. I això a sobre de tenir una feina i una vida. Sense IA els comptes no surten en absolut: el backlog creix més ràpid del que una persona pot atendre, els llançaments s'alenteixen, i el projecte acaba abandonat. Aquest és el resultat per defecte per als projectes populars amb un únic mantenidor.
 
-Amb eines d'IA, puc mantenir el ritme amb pegats de seguretat, actualitzacions d'Electron, informes d'usuaris i seguir traient funcionalitats noves. L'eina s'encarrega de la feina mecànica perquè pugui dedicar el meu temps limitat a les decisions i interaccions amb la comunitat que realment requereixen un humà.
-
-L'alternativa al manteniment assistit per IA no és "escriure-ho tot a mà." És "deixar que els issues s'acumulin i eventualment abandonar el projecte." Per a mantenidors de codi obert en solitari, la IA és una eina de sostenibilitat, no una drecera.
+Per als mantenidors en solitari, la IA no és una drecera. És la diferència entre continuar i marxar.
 
 ## Treballar a la vista
 
-Cada commit assistit per IA al repositori porta una etiqueta `Co-authored-by`. L'arxiu CLAUDE.md està inclòs al repositori on qualsevol pot llegir-lo. Això no és fer una declaració — és aprendre.
+Cada commit assistit per IA porta una etiqueta `Co-authored-by`. La configuració que dirigeix el comportament de la IA en aquest codi, CLAUDE.md, és al repositori perquè qualsevol la llegeixi. Podria perfectament amagar-ho. Guardar els prompts en carpetes personals, deixar les etiquetes fora, no mencionar mai quines parts va escriure la IA. Però per què? L'assistència d'IA ja no és una qüestió de *si*, és una qüestió de *com*. És una eina, i tractar-la com a tal vol dir ser obert sobre com s'utilitza.
 
-Vull entendre què funciona. Quins tipus de canvis assistits per IA són acceptats sense problemes per la comunitat? Quins generen fricció? Canvia la participació visible de la IA com la gent interactua amb el projecte? Són preguntes obertes, i l'única forma de respondre-les és ser obert sobre el procés.
+El que és interessant és el que canvia quan un projecte open source madur adopta aquestes eines. Què esdevé possible, quanta més feina pot portar un mantenidor en solitari, què esdevé més fàcil i què continua sent difícil. El següent article de la sèrie, [El flux de treball](/cat/articles/ai-assisted-open-source-workflow), és la forma pràctica del dia a dia.
 
-Si altres mantenidors trien mostrar o amagar el seu ús d'IA és assumpte seu. No m'interessa aquest debat. El que m'interessa és fer un experiment honest: mantenir un projecte obertament amb eines d'IA, veure quina és realment la resposta de la comunitat, i compartir el que aprengui.
-
-## Reflexió final
-
-La pregunta interessant no és "ha escrit la IA aquest codi?"
-
-És si el projecte funciona, si es manté i si els usuaris estan ben atesos. Per aquestes mesures, les eines d'IA estan fent exactament el que haurien — mantenir viu i receptiu un projecte útil quan l'alternativa és la decadència lenta.
-
-A [La trampa de l'automatització amb IA](/cat/articles/the-ai-automation-trap) vaig escriure sobre com la IA va eliminar la restricció de construir però no va eliminar la restricció de decidir. Aquest projecte és l'exemple viscut. La IA s'encarrega de construir. El decidir, el mantenir i el preocupar-se pels usuaris — això segueix sent completament humà. I sempre ho serà.
-
-Si vols veure com funciona això en el dia a dia — el flux de treball específic, les eines, els controls de qualitat — llegeix [Codi obert assistit per IA: el flux de treball](/cat/articles/ai-assisted-open-source-workflow).
+I hi ha una trampa esperant. A [La trampa de l'automatització amb IA](/cat/articles/the-ai-automation-trap) vaig escriure que la IA va eliminar la restricció de construir però no la de decidir. Com més deleguem a la màquina, més complexitat podem generar. I això vol dir més per mantenir, més per depurar, més per llegir. La IA no et treu d'aquell bucle, ni de cap altre. Passades de documentació, feina de re-arquitectura, inversions en observabilitat, la llarga cua de suport. Res d'això desapareix. Simplement passa més ràpid.

--- a/src/content/articles/cat/ai-assisted-open-source-workflow.mdx
+++ b/src/content/articles/cat/ai-assisted-open-source-workflow.mdx
@@ -1,0 +1,117 @@
+---
+title: "Codi obert assistit per IA: el flux de treball"
+description: "El flux de treball pràctic darrere del manteniment de teams-for-linux amb IA — des de CLAUDE.md fins a investigació, actualitzacions de dependències, implementació de funcionalitats i controls de qualitat."
+publishedDate: 2026-03-11
+tags: ["IA", "Codi Obert", "Desenvolupament de Software", "Teams for Linux"]
+draft: true
+---
+
+## Dels principis a la pràctica
+
+A [l'article complementari](/cat/articles/ai-assisted-open-source-maintenance) vaig cobrir què canvia la IA i què no quan mantens un projecte de codi obert. Aquest article és la continuació pràctica: el flux de treball real que faig servir dia a dia a teams-for-linux.
+
+Res d'això és teòric. És el que he anat assentant després de mesos d'iteració, i segueix evolucionant. El patró central és sempre el mateix: jo decideixo, la IA executa, i jo reviso tot abans que es publiqui.
+
+## CLAUDE.md: l'arxiu de restriccions
+
+Tota interacció amb l'eina d'IA comença amb CLAUDE.md. És el primer que l'agent llegeix en obrir el repositori, i dona forma a tot el que segueix.
+
+L'arxiu no és llarg, però és dens. Cobreix:
+
+**Invariants arquitectònics.** El `trayIconRenderer` s'ha d'inicialitzar abans que `mqttStatusMonitor`. Aquesta dependència s'ha trencat per contribuïdors diverses vegades. Sense CLAUDE.md documentant-ho, la IA refactoritzaria un sense considerar l'altre sense cap problema.
+
+**Límits de mòduls.** Quins arxius són responsables de què. La IA no hauria de moure funcionalitat entre mòduls sense direcció explícita, i l'arxiu deixa clars aquests límits.
+
+**Comandes de build i tests.** Com executar el projecte, com córrer els tests, què espera el pipeline de CI. Sona bàsic, però sense això la IA endevina — i endevina malament amb prou freqüència com per perdre temps.
+
+**Convencions de commits.** Etiquetes Co-authored-by, format de missatges de commit, nomenclatura de branques. La IA les segueix automàticament perquè estan documentades.
+
+**Restriccions conegudes.** Peculiaritats d'Electron, comportament específic de Wayland, restriccions de Trusted Types. Són les mines que atrapen a qui no coneix el codi. CLAUDE.md les senyalitza.
+
+L'arxiu és un document viu. Quan descobreixo un nou invariant o un nou perill, va a CLAUDE.md abans que a cap altre lloc. La inversió es paga en cada interacció posterior.
+
+## La fase d'investigació
+
+La majoria de canvis no trivials comencen amb investigació, no amb codi. El flux és així:
+
+**Descric el problema.** "Els usuaris reporten que la pantalla compartida falla a Wayland amb la darrera actualització d'Electron." O "Necessitem suportar Trusted Types per complir amb els nous requisits de CSP."
+
+**L'agent investiga.** Llegeix els arxius font rellevants, revisa el changelog d'Electron, consulta issues upstream i presenta el que troba. Això és exploració, no implementació. L'objectiu és entendre.
+
+**Spikes, no solucions.** Per a qualsevol cosa no òbvia, demano un spike — un prototip llençable que prova una hipòtesi específica. "Podem interceptar la crida a desktopCapturer abans que arribi al path de Wayland?" L'spike em diu si un enfocament és viable sense comprometre'm amb ell.
+
+**L'agent produeix un pla.** Un cop entenem el problema i hem validat un enfocament a través de spikes, l'agent escriu un pla estructurat: quins canvis es necessiten, quins arxius es veuen afectats, quins són els riscos i què s'hauria de provar.
+
+**Jo guio, després l'agent executa.** Reviso el pla, ajusto prioritats, assenyalo riscos que l'agent va passar per alt i dono el vistiplau. Només llavors comença la implementació real. Aquesta seqüència — investigar, spike, planificar, guiar — no és negociable. Saltar-se directament a la implementació és com s'acaba escrivint codi que resol el problema equivocat.
+
+## Actualitzacions de dependències
+
+Aquí és on l'assistència d'IA estalvia més temps en termes absoluts. El cicle d'actualització de dependències a teams-for-linux funciona més o menys així:
+
+**Detecció.** Dependabot o npm audit assenyalen una vulnerabilitat o dependència desactualitzada. Això passa diverses vegades per setmana.
+
+**Avaluació.** L'agent llegeix l'avís, revisa què va canviar a la dependència i avalua si ens afecta. Molts avisos són per paths de codi que no fem servir — l'agent pot identificar-los ràpidament.
+
+**Actualitzar i provar.** L'agent puja la versió, executa la suite de tests i comprova si hi ha canvis que trenquen alguna cosa. Per a versions minor i patch, això sol ser directe. Per a versions major, sovint desencadena una fase d'investigació.
+
+**Les actualitzacions d'Electron són especials.** Les versions major d'Electron trenquen coses regularment. L'actualització implica llegir la llista de canvis que trenquen compatibilitat, identificar quins afecten el nostre codi, fer spikes de solucions alternatives per a cadascun, i després implementar-les sistemàticament. Una sola actualització major d'Electron pot tocar dotzenes d'arxius. Sense assistència d'IA, reservaria un cap de setmana sencer per a cadascuna.
+
+**El criteri de llançament és meu.** L'agent pot actualitzar, provar i preparar un llançament. Però la decisió de publicar — si agrupar més correccions, si el moment és l'adequat, si els usuaris necessiten un avís previ — aquesta és meva.
+
+## Implementació de funcionalitats
+
+Quan una funcionalitat rep llum verda, el flux d'implementació segueix un patró consistent:
+
+**Especificació clara primer.** Descric què hauria de fer la funcionalitat, com s'hauria de comportar i — igual d'important — què *no* hauria de fer. Els límits d'abast importen. La IA sobreenginyarà amb gust si li ho permets.
+
+**Implementació incremental.** Les funcionalitats grans es divideixen en trossos petits i revisables. Cada tros s'implementa, prova i revisa abans de passar al següent. No és només bona pràctica — és essencial quan treballes amb IA, perquè detectar una direcció equivocada aviat costa minuts, mentre que detectar-la tard costa hores de feina llençable.
+
+**Tests juntament amb el codi.** L'agent escriu tests com a part de la implementació, no com a idea tardana. L'arxiu CLAUDE.md especifica les convencions de testing, així que els tests segueixen els patrons existents del projecte.
+
+**Revisar tot.** Cada peça de codi generat per IA es llegeix. No s'ulleja — es llegeix. Busco problemes subtils: respecta els límits de mòduls? Gestiona els casos extrems d'Electron? Manté la compatibilitat cap enrere on cal? La IA produeix bon codi la major part del temps, però "la major part del temps" no és suficient per a un projecte amb milers d'usuaris.
+
+## Gestió de canvis upstream
+
+La webapp de Teams canvia sense avís. Microsoft no publica un changelog del seu client web, i la programació defensiva contra aquests canvis és una de les parts més difícils de mantenir teams-for-linux.
+
+Quan alguna cosa es trenca, el flux és:
+
+**Triatge.** Arriben informes d'usuaris. L'agent ajuda a categoritzar-los: és una regressió al nostre codi o Microsoft va canviar alguna cosa upstream?
+
+**Investigació.** Si és upstream, l'agent examina què va canviar — comparant estructures DOM, peticions de xarxa o respostes d'API contra el que esperem. Aquesta feina detectivesca és tediosa i repetitiva, exactament el tipus de tasca que la IA gestiona bé.
+
+**Avaluació.** No tots els canvis upstream es poden sortejar. A vegades Microsoft elimina o restringeix alguna cosa de la qual depeníem, i cap quantitat de codi intel·ligent pot restaurar la funcionalitat. Reconèixer quan un problema no té solució és un judici humà.
+
+**Solució alternativa o acceptar.** Si existeix un workaround, l'implementem. Si no, ho comunico als usuaris honestament. L'agent ajuda a redactar la resposta, però la decisió i el to són meus.
+
+## Controls de qualitat
+
+Res es publica sense passar per un conjunt de controls de qualitat. No són aspiracionals — s'apliquen.
+
+**CI ha de passar.** El pipeline de GitHub Actions executa linting, comprovació de tipus i la suite de tests. Sense excepcions.
+
+**Etiquetes Co-authored-by a cada commit assistit per IA.** Això és transparència no negociable. Si la IA va ajudar a escriure-ho, el commit ho diu.
+
+**Revisió manual de cada canvi.** Llegeixo cada diff abans que es faci commit. La IA pot proposar canvis, però jo decideixo què entra realment al codi.
+
+**Notes de llançament que expliquen el "per què."** L'agent redacta les notes de llançament, però jo les edito per assegurar-me que són útils per als usuaris — no només una llista d'arxius canviats, sinó una explicació de què va millorar i per què importa.
+
+## El que he après
+
+Després de mesos treballant així, algunes coses destaquen.
+
+**El flux de treball és el producte.** L'eina d'IA específica importa menys que el procés que l'envolta. Investigar abans d'implementar. Spikes abans de comprometre's. Revisar abans de fusionar. Aquestes pràctiques fan que l'assistència d'IA sigui efectiva; sense elles, només estàs generant codi més ràpid sense generar millors resultats.
+
+**CLAUDE.md és la inversió de major apalancament.** Cada hora invertida documentant invariants, límits i convencions estalvia moltes hores corregint la IA després. És l'equivalent a la documentació d'onboarding — excepte que la IA realment la llegeix cada vegada.
+
+**La feina del mantenidor canvia, però no es redueix.** Passo menys temps escrivint boilerplate i més temps revisant, decidint i comunicant. Les hores totals no han disminuït gaire. El que va canviar és que aquestes hores produeixen més valor.
+
+**La transparència no costa res.** Ser obert sobre l'ús d'IA no ha perjudicat el projecte. Les etiquetes Co-authored-by i l'arxiu CLAUDE.md són allà perquè qualsevol els vegi. Els usuaris que es preocupen pels resultats — funciona l'app, es manté, s'atenen els issues? — jutgen el projecte per aquests mèrits, no per les eines fetes servir.
+
+## Reflexió final
+
+Aquest flux de treball no és una plantilla. És el que funciona per a un projecte específic amb un mantenidor específic. La teva versió serà diferent — eines diferents, restriccions diferents, prioritats diferents.
+
+Però el patró subjacent aplica àmpliament: els humans decideixen, la IA executa, els humans revisen. Salta't qualsevol d'aquests passos i o no estàs aprofitant la IA efectivament o no estàs mantenint la qualitat que els teus usuaris mereixen.
+
+L'[article de principis](/cat/articles/ai-assisted-open-source-maintenance) cobreix el perquè. Aquest article va cobrir el com. Junts, són la imatge completa de com es veu realment el manteniment de codi obert assistit per IA a la pràctica.

--- a/src/content/articles/cat/ai-assisted-open-source-workflow.mdx
+++ b/src/content/articles/cat/ai-assisted-open-source-workflow.mdx
@@ -132,7 +132,7 @@ Després de mesos treballant així, algunes coses destaquen.
 
 **La feina del mantenidor canvia, però no es redueix.** Passo menys temps escrivint boilerplate i més temps revisant, decidint i comunicant. Les hores totals no han disminuït gaire. El que va canviar és que aquestes hores produeixen més valor.
 
-**La transparència no costa res.** Ser obert sobre l'ús d'IA no ha perjudicat el projecte. Les etiquetes Co-authored-by i l'arxiu CLAUDE.md són allà perquè qualsevol els vegi. Els usuaris que es preocupen pels resultats — funciona l'app, es manté, s'atenen els issues? — jutgen el projecte per aquests mèrits, no per les eines fetes servir.
+**Treballar a la vista t'ensenya coses.** Les etiquetes Co-authored-by i l'arxiu CLAUDE.md són allà perquè qualsevol els vegi. Aquesta visibilitat converteix el projecte en un experiment d'aprenentatge — quins canvis assistits per IA funcionen bé, quins generen fricció, què li importa realment a la comunitat. No pots aprendre res d'això si amagues el procés.
 
 ## Reflexió final
 

--- a/src/content/articles/cat/ai-assisted-open-source-workflow.mdx
+++ b/src/content/articles/cat/ai-assisted-open-source-workflow.mdx
@@ -32,7 +32,7 @@ L'arxiu és un document viu. Quan descobreixo un nou invariant o un nou perill, 
 
 ## La fase d'investigació
 
-La majoria de canvis no trivials comencen amb investigació, no amb codi. El flux és així:
+La majoria de canvis no trivials comencen amb investigació, no amb codi. El flux complet és així:
 
 **Descric el problema.** "Els usuaris reporten que la pantalla compartida falla a Wayland amb la darrera actualització d'Electron." O "Necessitem suportar Trusted Types per complir amb els nous requisits de CSP."
 
@@ -42,7 +42,9 @@ La majoria de canvis no trivials comencen amb investigació, no amb codi. El flu
 
 **L'agent produeix un pla.** Un cop entenem el problema i hem validat un enfocament a través de spikes, l'agent escriu un pla estructurat: quins canvis es necessiten, quins arxius es veuen afectats, quins són els riscos i què s'hauria de provar.
 
-**Jo guio, després l'agent executa.** Reviso el pla, ajusto prioritats, assenyalo riscos que l'agent va passar per alt i dono el vistiplau. Només llavors comença la implementació real. Aquesta seqüència — investigar, spike, planificar, guiar — no és negociable. Saltar-se directament a la implementació és com s'acaba escrivint codi que resol el problema equivocat.
+**Jo guio, després l'agent executa.** Reviso el pla, ajusto prioritats, assenyalo riscos que l'agent va passar per alt i dono el vistiplau. Només llavors comença la implementació real.
+
+No tots els canvis necessiten la seqüència completa. Una correcció de bug directa pot saltar-se l'spike i anar directament de la investigació a la implementació. Una actualització complexa d'Electron pot necessitar múltiples rondes de spikes al llarg de diverses sessions. El procés s'adapta al problema. El que no canvia és que entenc el que està passant abans de comprometre'm amb un enfocament.
 
 ## Actualitzacions de dependències
 
@@ -69,6 +71,30 @@ Quan una funcionalitat rep llum verda, el flux d'implementació segueix un patr�
 **Tests juntament amb el codi.** L'agent escriu tests com a part de la implementació, no com a idea tardana. L'arxiu CLAUDE.md especifica les convencions de testing, així que els tests segueixen els patrons existents del projecte.
 
 **Revisar tot.** Cada peça de codi generat per IA es llegeix. No s'ulleja — es llegeix. Busco problemes subtils: respecta els límits de mòduls? Gestiona els casos extrems d'Electron? Manté la compatibilitat cap enrere on cal? La IA produeix bon codi la major part del temps, però "la major part del temps" no és suficient per a un projecte amb milers d'usuaris.
+
+## Mantenir el context net
+
+Quan una implementació està acabada, segueixo una pràctica tradicional: el resultat s'emmagatzema com un ADR (Architecture Decision Record). El document d'investigació que hi va portar s'elimina.
+
+Pot sonar malbaratador — per què llençar la investigació? — però és deliberat. La investigació sempre és recuperable de l'historial de git si la necessito. El que importa és mantenir net el context actual. Si els documents d'investigació vells s'acumulen al repositori, la IA els llegeix i es confon sobre què és actual versus què és històric. Comença a referenciar resultats de spikes obsolets o plans superats.
+
+L'ADR captura la decisió i la seva justificació. Això és el que les sessions futures necessiten. El camí desordenat que hi va portar — els carrerons sense sortida, els spikes descartats, els enfocaments abandonats — és soroll un cop la decisió està presa. Git ho recorda. El directori de treball no necessita fer-ho.
+
+## Tipus de sessió
+
+El flux d'investigació-a-implementació no és l'únic tipus de sessió que executo. El manteniment implica diversos tipus de sessions recurrents, cadascun amb el seu propi focus:
+
+**Sessions de seguretat.** Revisar resultats de npm audit, avaluar avisos, pegar vulnerabilitats. S'executen freqüentment perquè l'ecosistema npm mai deixa de produir avisos.
+
+**Neteja de documentació.** Actualitzar seccions del README, netejar comentaris inline que s'han desviat del codi, refrescar CLAUDE.md amb nous invariants descoberts des de la darrera passada.
+
+**Mètriques i revisions de salut.** Revisar tendències d'issues, activitat de contribuïdors, temps de build, canvis en cobertura de tests. Entendre la trajectòria del projecte, no només l'estat actual.
+
+**Actualitzacions de dependències.** El cicle descrit més amunt — detecció, avaluació, actualització, prova, decisió de llançament.
+
+Cada tipus de sessió segueix el mateix patró central: jo estableixo l'abast, la IA executa dins d'ell, jo reviso els resultats. La diferència és a què estem mirant, no com treballem.
+
+Ara mateix aquestes sessions s'executen quan hi arribo. M'agradaria semi-automatitzar les recurrents — tenir un informe mensual generat que mostri tendències, assenyali coses que necessiten atenció i em doni una foto sense haver de recordar-me de mirar. El bot de triatge ja fa una versió d'això per als issues. Estendre aquest patró a la postura de seguretat, la frescor de dependències i la deriva de documentació és el següent pas natural.
 
 ## Gestió de canvis upstream
 

--- a/src/content/articles/cat/ai-assisted-open-source-workflow.mdx
+++ b/src/content/articles/cat/ai-assisted-open-source-workflow.mdx
@@ -116,7 +116,7 @@ Res es publica sense passar per un conjunt de controls de qualitat. No són aspi
 
 **Etiquetes Co-authored-by a cada commit assistit per IA.** Això és transparència no negociable. Si la IA va ajudar a escriure-ho, el commit ho diu.
 
-**Revisió manual de cada canvi.** Llegeixo cada diff abans que es faci commit. La IA pot proposar canvis, però jo decideixo què entra realment al codi.
+**Revisió manual de cada canvi.** Llegeixo cada diff abans que es faci commit. Sense excepcions per al codi generat per IA.
 
 **Notes de llançament que expliquen el "per què."** L'agent redacta les notes de llançament, però jo les edito per assegurar-me que són útils per als usuaris — no només una llista d'arxius canviats, sinó una explicació de què va millorar i per què importa.
 
@@ -130,7 +130,7 @@ Després de mesos treballant així, algunes coses destaquen.
 
 **La feina del mantenidor canvia, però no es redueix.** Passo menys temps escrivint boilerplate i més temps revisant, decidint i comunicant. Les hores totals no han disminuït gaire. El que va canviar és que aquestes hores produeixen més valor.
 
-**Treballar a la vista t'ensenya coses.** Les etiquetes Co-authored-by i l'arxiu CLAUDE.md són allà perquè qualsevol els vegi. Aquesta visibilitat converteix el projecte en un experiment d'aprenentatge — quins canvis assistits per IA funcionen bé, quins generen fricció, què li importa realment a la comunitat. No pots aprendre res d'això si amagues el procés.
+**Tracta-la com un equip, no com una eina.** Gairebé has de fer-ho. Un cop has construït prou restriccions al voltant de la IA — CLAUDE.md, el cicle d'investigació-llavors-spike, la revisió manual, els controls de CI — ja no estàs realment usant una eina, estàs dirigint un sistema. El patró és el mateix que aplicaries a qualsevol software que creix: construir confiança amb dades, afegir solidesa a mesura que avances, simplificar o treure el que deixa de guanyar-se el seu lloc. La diferència és que els cicles van més ràpid.
 
 ## Reflexió final
 

--- a/src/content/articles/cat/ai-assisted-open-source-workflow.mdx
+++ b/src/content/articles/cat/ai-assisted-open-source-workflow.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Codi obert assistit per IA: el flux de treball"
-description: "El flux de treball pràctic darrere del manteniment de teams-for-linux amb IA — des de CLAUDE.md fins a investigació, actualitzacions de dependències, implementació de funcionalitats i controls de qualitat."
+description: "El flux de treball pràctic darrere del manteniment de teams-for-linux amb IA: des de CLAUDE.md fins a investigació, actualitzacions de dependències, implementació de funcionalitats i controls de qualitat."
 publishedDate: 2026-03-11
 tags: ["IA", "Codi Obert", "Desenvolupament de Software", "Teams for Linux"]
 draft: true
@@ -8,134 +8,44 @@ draft: true
 
 ## Dels principis a la pràctica
 
-A [l'article complementari](/cat/articles/ai-assisted-open-source-maintenance) vaig cobrir què canvia la IA i què no quan mantens un projecte de codi obert. Aquest article és la continuació pràctica: el flux de treball real que faig servir dia a dia a teams-for-linux.
+L'[article complementari](/cat/articles/ai-assisted-open-source-maintenance) va cobrir què canvia la IA en mantenir un projecte open source. Aquest és el flux de treball del dia a dia. El patró central sempre és el mateix: jo decideixo, la IA executa, jo reviso. Res d'això és teòric. És el que m'ha quedat després de mesos d'iteració, i continua evolucionant.
 
-Res d'això és teòric. És el que he anat assentant després de mesos d'iteració, i segueix evolucionant. El patró central és sempre el mateix: jo decideixo, la IA executa, i jo reviso tot abans que es publiqui.
+## CLAUDE.md com a document viu
 
-## CLAUDE.md: l'arxiu de restriccions
+Cada interacció comença amb CLAUDE.md. L'arxiu és curt però dens: invariants arquitectòniques, fronteres entre mòduls, comandes de build i test, convencions de commit, restriccions conegudes com les peculiaritats d'Electron o el comportament específic de Wayland. Per exemple, aquest projecte prohibeix loguejar qualsevol cosa sensible com URLs de broker, adreces d'email o tokens d'autenticació. És exactament el tipus de detall que una IA escamparà amablement per crides a `console.info` tret que li diguis que no. Quan descobreixo un nou invariant o footgun, va a l'arxiu abans que res. La inversió s'amortitza en cada interacció posterior.
 
-Tota interacció amb l'eina d'IA comença amb CLAUDE.md. És el primer que l'agent llegeix en obrir el repositori, i dona forma a tot el que segueix.
+## Investigar abans de programar
 
-L'arxiu no és llarg, però és dens. Cobreix:
-
-**Invariants arquitectònics.** El `trayIconRenderer` s'ha d'inicialitzar abans que `mqttStatusMonitor`. Aquesta dependència s'ha trencat per contribuïdors diverses vegades. Sense CLAUDE.md documentant-ho, la IA refactoritzaria un sense considerar l'altre sense cap problema.
-
-**Límits de mòduls.** Quins arxius són responsables de què. La IA no hauria de moure funcionalitat entre mòduls sense direcció explícita, i l'arxiu deixa clars aquests límits.
-
-**Comandes de build i tests.** Com executar el projecte, com córrer els tests, què espera el pipeline de CI. Sona bàsic, però sense això la IA endevina — i endevina malament amb prou freqüència com per perdre temps.
-
-**Convencions de commits.** Etiquetes Co-authored-by, format de missatges de commit, nomenclatura de branques. La IA les segueix automàticament perquè estan documentades.
-
-**Restriccions conegudes.** Peculiaritats d'Electron, comportament específic de Wayland, restriccions de Trusted Types. Són les mines que atrapen a qui no coneix el codi. CLAUDE.md les senyalitza.
-
-L'arxiu és un document viu. Quan descobreixo un nou invariant o un nou perill, va a CLAUDE.md abans que a cap altre lloc. La inversió es paga en cada interacció posterior.
-
-## La fase d'investigació
-
-La majoria de canvis no trivials comencen amb investigació, no amb codi. El flux complet és així:
-
-**Descric el problema.** "Els usuaris reporten que la pantalla compartida falla a Wayland amb la darrera actualització d'Electron." O "Necessitem suportar Trusted Types per complir amb els nous requisits de CSP."
-
-**L'agent investiga.** Llegeix els arxius font rellevants, revisa el changelog d'Electron, consulta issues upstream i presenta el que troba. Això és exploració, no implementació. L'objectiu és entendre.
-
-**Spikes, no solucions.** Per a qualsevol cosa no òbvia, demano un spike — un prototip llençable que prova una hipòtesi específica. "Podem interceptar la crida a desktopCapturer abans que arribi al path de Wayland?" L'spike em diu si un enfocament és viable sense comprometre'm amb ell.
-
-**L'agent produeix un pla.** Un cop entenem el problema i hem validat un enfocament a través de spikes, l'agent escriu un pla estructurat: quins canvis es necessiten, quins arxius es veuen afectats, quins són els riscos i què s'hauria de provar.
-
-**Jo guio, després l'agent executa.** Reviso el pla, ajusto prioritats, assenyalo riscos que l'agent va passar per alt i dono el vistiplau. Només llavors comença la implementació real.
-
-No tots els canvis necessiten la seqüència completa. Una correcció de bug directa pot saltar-se l'spike i anar directament de la investigació a la implementació. Una actualització complexa d'Electron pot necessitar múltiples rondes de spikes al llarg de diverses sessions. El procés s'adapta al problema. El que no canvia és que entenc el que està passant abans de comprometre'm amb un enfocament.
+La majoria dels canvis no trivials comencen amb investigació, no amb implementació. Descric el problema ("la pantalla compartida falla a Wayland amb la darrera actualització d'Electron"); l'agent investiga el codi rellevant, el changelog i els issues upstream. Per a qualsevol cosa no òbvia demano un spike: un prototip d'usar i llençar que prova una hipòtesi concreta. Un cop un enfocament és viable, l'agent escriu un pla. El reviso, marco riscos, i només llavors comença la implementació. Els bugs simples es salten el spike; les actualitzacions complexes d'Electron necessiten diverses rondes. El procés s'adapta; el que no canvia és que entenc què està passant abans de comprometre'm amb un enfocament.
 
 ## Actualitzacions de dependències
 
-Aquí és on l'assistència d'IA estalvia més temps en termes absoluts. El cicle d'actualització de dependències a teams-for-linux funciona més o menys així:
+Aquí és on l'assistència d'IA estalvia més temps. Dependabot o npm audit marca alguna cosa; l'agent llegeix l'avís, comprova què va canviar, i jutja si ens afecta. Molts avisos són per a rutes de codi que no fem servir. Les versions menors i de pegat solen ser senzilles. Les versions majors sovint desencadenen una fase d'investigació. Les majors d'Electron són especials: toquen rutinàriament desenes d'arxius, i sense IA pressupostaria un cap de setmana sencer per actualització. La decisió de llançament, si llançar ara o agrupar més correccions, segueix sent meva.
 
-**Detecció.** Dependabot o npm audit assenyalen una vulnerabilitat o dependència desactualitzada. Això passa diverses vegades per setmana.
+## Funcionalitats i l'hàbit de context net
 
-**Avaluació.** L'agent llegeix l'avís, revisa què va canviar a la dependència i avalua si ens afecta. Molts avisos són per paths de codi que no fem servir — l'agent pot identificar-los ràpidament.
+Quan una funcionalitat rep llum verda, el flux és consistent: especificació clara incloent el que *no* s'ha de fer, implementació incremental en trossos revisables, tests escrits en paral·lel (la IA segueix els patrons documentats a CLAUDE.md) i una lectura completa de cada diff. La IA produeix bon codi la major part del temps, però "la major part del temps" no és prou per a milers d'usuaris.
 
-**Actualitzar i provar.** L'agent puja la versió, executa la suite de tests i comprova si hi ha canvis que trenquen alguna cosa. Per a versions minor i patch, això sol ser directe. Per a versions major, sovint desencadena una fase d'investigació.
+Quan la feina acaba, el resultat es converteix en un ADR. La investigació que va portar fins allà s'esborra. Git recorda els carrerons sense sortida; el directori de treball no cal que ho faci. Els documents d'investigació vells s'acumulen, es tornen a llegir i confonen la IA sobre què és actual i què és històric.
 
-**Les actualitzacions d'Electron són especials.** Les versions major d'Electron trenquen coses regularment. L'actualització implica llegir la llista de canvis que trenquen compatibilitat, identificar quins afecten el nostre codi, fer spikes de solucions alternatives per a cadascun, i després implementar-les sistemàticament. Una sola actualització major d'Electron pot tocar dotzenes d'arxius. Sense assistència d'IA, reservaria un cap de setmana sencer per a cadascuna.
+## Altres sessions recurrents
 
-**El judici de llançament és meu.** L'agent pot actualitzar, provar i preparar un llançament. Però la decisió de publicar — si agrupar més correccions, si el moment és l'adequat, si els usuaris necessiten un avís previ — aquesta és meva.
+Les actualitzacions de dependències són el tipus de sessió més freqüent, però no l'únic. Les sessions de seguretat avaluen i peguen avisos. Les passades de documentació actualitzen READMEs i refresquen CLAUDE.md amb invariants acabats de descobrir. Les sessions de mètriques miren tendències d'issues, activitat de contribuïdors, temps de build, canvis en cobertura de tests. Cadascuna segueix la mateixa forma: jo estableixo l'abast, la IA executa, jo reviso.
 
-## Implementació de funcionalitats
+## Gestionar canvis upstream
 
-Quan una funcionalitat rep llum verda, el flux d'implementació segueix un patró consistent:
-
-**Especificació clara primer.** Descric què hauria de fer la funcionalitat, com s'hauria de comportar i — igual d'important — què *no* hauria de fer. Els límits d'abast importen. La IA sobreenginyarà amb gust si li ho permets.
-
-**Implementació incremental.** Les funcionalitats grans es divideixen en trossos petits i revisables. Cada tros s'implementa, prova i revisa abans de passar al següent. No és només bona pràctica — és essencial quan treballes amb IA, perquè detectar una direcció equivocada aviat costa minuts, mentre que detectar-la tard costa hores de feina llençable.
-
-**Tests juntament amb el codi.** L'agent escriu tests com a part de la implementació, no com a idea tardana. L'arxiu CLAUDE.md especifica les convencions de testing, així que els tests segueixen els patrons existents del projecte.
-
-**Revisar tot.** Cada peça de codi generat per IA es llegeix. No s'ulleja — es llegeix. Busco problemes subtils: respecta els límits de mòduls? Gestiona els casos extrems d'Electron? Manté la compatibilitat cap enrere on cal? La IA produeix bon codi la major part del temps, però "la major part del temps" no és suficient per a un projecte amb milers d'usuaris.
-
-## Mantenir el context net
-
-Quan una implementació està acabada, segueixo una pràctica tradicional: el resultat s'emmagatzema com un ADR (Architecture Decision Record). El document d'investigació que hi va portar s'elimina.
-
-Pot sonar malbaratador — per què llençar la investigació? — però és deliberat. La investigació sempre és recuperable de l'historial de git si la necessito. El que importa és mantenir net el context actual. Si els documents d'investigació vells s'acumulen al repositori, la IA els llegeix i es confon sobre què és actual versus què és històric. Comença a referenciar resultats de spikes obsolets o plans superats.
-
-L'ADR captura la decisió i la seva justificació. Això és el que les sessions futures necessiten. El camí desordenat que hi va portar — els carrerons sense sortida, els spikes descartats, els enfocaments abandonats — és soroll un cop la decisió està presa. Git ho recorda. El directori de treball no necessita fer-ho.
-
-## Tipus de sessió
-
-Les actualitzacions de dependències són el tipus de sessió més freqüent, però no l'únic. Més enllà del cicle descrit més amunt, hi ha altres tipus recurrents que componen la major part del manteniment:
-
-**Sessions de seguretat.** Revisar resultats de npm audit, avaluar avisos, pegar vulnerabilitats. S'executen freqüentment perquè l'ecosistema npm mai deixa de produir avisos.
-
-**Neteja de documentació.** Actualitzar seccions del README, netejar comentaris inline que s'han desviat del codi, refrescar CLAUDE.md amb nous invariants descoberts des de la darrera passada.
-
-**Mètriques i revisions de salut.** Revisar tendències d'issues, activitat de contribuïdors, temps de build, canvis en cobertura de tests. Entendre la trajectòria del projecte, no només l'estat actual.
-
-Cada tipus de sessió — incloses les actualitzacions de dependències — segueix el mateix patró central: jo estableixo l'abast, la IA executa dins d'ell, jo reviso els resultats. La diferència és a què estem mirant, no com treballem.
-
-Ara mateix aquestes sessions s'executen quan hi arribo. M'agradaria semi-automatitzar les recurrents — tenir un informe mensual generat que mostri tendències, assenyali coses que necessiten atenció i em doni una foto sense haver de recordar-me de mirar. El bot de triatge ja fa una versió d'això per als issues. Estendre aquest patró a la postura de seguretat, la frescor de dependències i la deriva de documentació és el següent pas natural.
-
-## Gestió de canvis upstream
-
-La webapp de Teams canvia sense avís. Microsoft no publica un changelog del seu client web, i la programació defensiva contra aquests canvis és una de les parts més difícils de mantenir teams-for-linux.
-
-Quan alguna cosa es trenca, el flux és:
-
-**Triatge.** Arriben informes d'usuaris. L'agent ajuda a categoritzar-los: és una regressió al nostre codi o Microsoft va canviar alguna cosa upstream?
-
-**Investigació.** Si és upstream, l'agent examina què va canviar — comparant estructures DOM, peticions de xarxa o respostes d'API contra el que esperem. Aquesta feina detectivesca és tediosa i repetitiva, exactament el tipus de tasca que la IA gestiona bé.
-
-**Avaluació.** No tots els canvis upstream es poden sortejar. A vegades Microsoft elimina o restringeix alguna cosa de la qual depeníem, i cap quantitat de codi intel·ligent pot restaurar la funcionalitat. Reconèixer quan un problema no té solució és un judici humà.
-
-**Solució alternativa o acceptar.** Si existeix un workaround, l'implementem. Si no, ho comunico als usuaris honestament. L'agent ajuda a redactar la resposta, però la decisió i el to són meus.
+La web app de Teams canvia sense avís previ, i programar defensivament contra aquests canvis és una de les parts més difícils d'aquest projecte. Quan alguna cosa es trenca, l'agent m'ajuda a categoritzar. És una regressió nostra o un canvi upstream? Després investiga diferències a DOM, xarxa o respostes d'API. Alguns canvis tenen workaround; d'altres no. Reconèixer quan un problema no té solució és una decisió humana, i la resposta als usuaris és meva.
 
 ## Controls de qualitat
 
-Res es publica sense passar per un conjunt de controls de qualitat. No són aspiracionals — s'apliquen.
+Res es llança sense passar els controls aplicats: CI ha de passar (linting, type checking, suite de tests completa, sense excepcions), cada commit assistit per IA porta una etiqueta `Co-authored-by`, cada diff es llegeix manualment, i les release notes s'editen per explicar el *perquè* en lloc de llistar arxius.
 
-**CI ha de passar.** El pipeline de GitHub Actions executa linting, comprovació de tipus i la suite de tests. Sense excepcions.
+## Tracta-la com un equip
 
-**Etiquetes Co-authored-by a cada commit assistit per IA.** Això és transparència no negociable. Si la IA va ajudar a escriure-ho, el commit ho diu.
-
-**Revisió manual de cada canvi.** Llegeixo cada diff abans que es faci commit. Sense excepcions per al codi generat per IA.
-
-**Notes de llançament que expliquen el "per què."** L'agent redacta les notes de llançament, però jo les edito per assegurar-me que són útils per als usuaris — no només una llista d'arxius canviats, sinó una explicació de què va millorar i per què importa.
-
-## El que he après
-
-Després de mesos treballant així, algunes coses destaquen.
-
-**El flux de treball és el producte.** L'eina d'IA específica importa menys que el procés que l'envolta. Investigar abans d'implementar. Spikes abans de comprometre's. Revisar abans de fusionar. Aquestes pràctiques fan que l'assistència d'IA sigui efectiva; sense elles, només estàs generant codi més ràpid sense generar millors resultats.
-
-**CLAUDE.md és la inversió de major apalancament.** Cada hora invertida documentant invariants, límits i convencions estalvia moltes hores corregint la IA després. És l'equivalent a la documentació d'onboarding — excepte que la IA realment la llegeix cada vegada.
-
-**La feina del mantenidor canvia, però no es redueix.** Passo menys temps escrivint boilerplate i més temps revisant, decidint i comunicant. Les hores totals no han disminuït gaire. El que va canviar és que aquestes hores produeixen més valor.
-
-**Tracta-la com un equip, no com una eina.** Gairebé has de fer-ho. Un cop has construït prou restriccions al voltant de la IA — CLAUDE.md, el cicle d'investigació-llavors-spike, la revisió manual, els controls de CI — ja no estàs realment usant una eina, estàs dirigint un sistema. El patró és el mateix que aplicaries a qualsevol software que creix: construir confiança amb dades, afegir solidesa a mesura que avances, simplificar o treure el que deixa de guanyar-se el seu lloc. La diferència és que els cicles van més ràpid.
+Un cop has construït prou restriccions al voltant de la IA (CLAUDE.md, el cicle d'investigació-llavors-spike, la revisió manual, els controls de CI), ja no estàs usant una eina. Estàs dirigint un sistema. El patró és el mateix que aplicaries a qualsevol software que creix: construir confiança amb dades, afegir solidesa a mesura que avances, simplificar o treure el que deixa de guanyar-se el seu lloc. La diferència és que els cicles van més ràpid.
 
 ## Reflexió final
 
-Aquest flux de treball no és una plantilla. És el que funciona per a un projecte específic amb un mantenidor específic. La teva versió serà diferent — eines diferents, restriccions diferents, prioritats diferents.
+Aquest flux de treball no és una plantilla. És el que funciona per a un projecte específic amb un mantenidor específic. La teva versió serà diferent. Però el patró subjacent és portable: un humà al començament, un humà al final, l'eina al mig. Salta't qualsevol d'aquests extrems i o no estàs aprofitant la IA efectivament o no estàs mantenint la qualitat que els teus usuaris mereixen.
 
-Però el patró subjacent és portable: un humà al començament, un humà al final, l'eina al mig. Salta't qualsevol d'aquests extrems i o no estàs aprofitant la IA efectivament o no estàs mantenint la qualitat que els teus usuaris mereixen.
-
-L'[article de principis](/cat/articles/ai-assisted-open-source-maintenance) cobreix el perquè. Aquest article va cobrir el com. Junts, són la imatge completa de com es veu realment el manteniment de codi obert assistit per IA a la pràctica.
+L'[article de principis](/cat/articles/ai-assisted-open-source-maintenance) va cobrir el perquè. Aquest article va cobrir el com. Junts són la imatge completa.

--- a/src/content/articles/cat/ai-assisted-open-source-workflow.mdx
+++ b/src/content/articles/cat/ai-assisted-open-source-workflow.mdx
@@ -58,7 +58,7 @@ Aquí és on l'assistència d'IA estalvia més temps en termes absoluts. El cicl
 
 **Les actualitzacions d'Electron són especials.** Les versions major d'Electron trenquen coses regularment. L'actualització implica llegir la llista de canvis que trenquen compatibilitat, identificar quins afecten el nostre codi, fer spikes de solucions alternatives per a cadascun, i després implementar-les sistemàticament. Una sola actualització major d'Electron pot tocar dotzenes d'arxius. Sense assistència d'IA, reservaria un cap de setmana sencer per a cadascuna.
 
-**El criteri de llançament és meu.** L'agent pot actualitzar, provar i preparar un llançament. Però la decisió de publicar — si agrupar més correccions, si el moment és l'adequat, si els usuaris necessiten un avís previ — aquesta és meva.
+**El judici de llançament és meu.** L'agent pot actualitzar, provar i preparar un llançament. Però la decisió de publicar — si agrupar més correccions, si el moment és l'adequat, si els usuaris necessiten un avís previ — aquesta és meva.
 
 ## Implementació de funcionalitats
 

--- a/src/content/articles/cat/ai-assisted-open-source-workflow.mdx
+++ b/src/content/articles/cat/ai-assisted-open-source-workflow.mdx
@@ -82,7 +82,7 @@ L'ADR captura la decisió i la seva justificació. Això és el que les sessions
 
 ## Tipus de sessió
 
-El flux d'investigació-a-implementació no és l'únic tipus de sessió que executo. El manteniment implica diversos tipus de sessions recurrents, cadascun amb el seu propi focus:
+Les actualitzacions de dependències són el tipus de sessió més freqüent, però no l'únic. Més enllà del cicle descrit més amunt, hi ha altres tipus recurrents que componen la major part del manteniment:
 
 **Sessions de seguretat.** Revisar resultats de npm audit, avaluar avisos, pegar vulnerabilitats. S'executen freqüentment perquè l'ecosistema npm mai deixa de produir avisos.
 
@@ -90,9 +90,7 @@ El flux d'investigació-a-implementació no és l'únic tipus de sessió que exe
 
 **Mètriques i revisions de salut.** Revisar tendències d'issues, activitat de contribuïdors, temps de build, canvis en cobertura de tests. Entendre la trajectòria del projecte, no només l'estat actual.
 
-**Actualitzacions de dependències.** El cicle descrit més amunt — detecció, avaluació, actualització, prova, decisió de llançament.
-
-Cada tipus de sessió segueix el mateix patró central: jo estableixo l'abast, la IA executa dins d'ell, jo reviso els resultats. La diferència és a què estem mirant, no com treballem.
+Cada tipus de sessió — incloses les actualitzacions de dependències — segueix el mateix patró central: jo estableixo l'abast, la IA executa dins d'ell, jo reviso els resultats. La diferència és a què estem mirant, no com treballem.
 
 Ara mateix aquestes sessions s'executen quan hi arribo. M'agradaria semi-automatitzar les recurrents — tenir un informe mensual generat que mostri tendències, assenyali coses que necessiten atenció i em doni una foto sense haver de recordar-me de mirar. El bot de triatge ja fa una versió d'això per als issues. Estendre aquest patró a la postura de seguretat, la frescor de dependències i la deriva de documentació és el següent pas natural.
 

--- a/src/content/articles/cat/ai-assisted-open-source-workflow.mdx
+++ b/src/content/articles/cat/ai-assisted-open-source-workflow.mdx
@@ -136,6 +136,6 @@ Després de mesos treballant així, algunes coses destaquen.
 
 Aquest flux de treball no és una plantilla. És el que funciona per a un projecte específic amb un mantenidor específic. La teva versió serà diferent — eines diferents, restriccions diferents, prioritats diferents.
 
-Però el patró subjacent aplica àmpliament: els humans decideixen, la IA executa, els humans revisen. Salta't qualsevol d'aquests passos i o no estàs aprofitant la IA efectivament o no estàs mantenint la qualitat que els teus usuaris mereixen.
+Però el patró subjacent és portable: un humà al començament, un humà al final, l'eina al mig. Salta't qualsevol d'aquests extrems i o no estàs aprofitant la IA efectivament o no estàs mantenint la qualitat que els teus usuaris mereixen.
 
 L'[article de principis](/cat/articles/ai-assisted-open-source-maintenance) cobreix el perquè. Aquest article va cobrir el com. Junts, són la imatge completa de com es veu realment el manteniment de codi obert assistit per IA a la pràctica.

--- a/src/content/articles/en/ai-assisted-open-source-cadences.mdx
+++ b/src/content/articles/en/ai-assisted-open-source-cadences.mdx
@@ -8,52 +8,30 @@ draft: true
 
 ## From One Project to Several
 
-The [first article in this series](/en/articles/ai-assisted-open-source-maintenance) asked what AI changes about maintaining an open-source project, and answered it through the lens of teams-for-linux — one codebase, seven years old, single maintainer. The [second article](/en/articles/ai-assisted-open-source-workflow) was the practical workflow that keeps it going. Both stayed inside the long-lived cadence.
+The [first article](/en/articles/ai-assisted-open-source-maintenance) asked what AI changes about maintaining an open-source project, through the lens of one 7-year codebase. The [second](/en/articles/ai-assisted-open-source-workflow) was the workflow that keeps it going. Both stayed inside a single long-lived cadence. This one steps out of that frame: AI assistance makes running several projects in parallel — at different speeds — actually feasible, and that changes what the workflow has to handle.
 
-This one steps out of that frame. AI assistance doesn't just make a single long-lived project more sustainable; it makes running several projects in parallel — at different speeds, with different lifecycles — actually feasible. That changes what the workflow has to handle.
+## Four Cadences
 
-## Four Cadences I Work In
+teams-for-linux is the long-lived one: seven years of history, thousands of users, the full harness.
 
-teams-for-linux is the long-lived one. Seven years of history, thousands of users, the full harness — CLAUDE.md, ADRs, QA gates, careful release judgement. Article 2 was about this cadence in detail.
+bonnie-wee-plot is seasonal — a Scottish allotment app where the features that matter in March (sowing windows) are different from the ones that matter in August (harvest, blight watch). The codebase grows in chapters, with the gardening year telling it what to build next.
 
-bonnie-wee-plot is seasonal. It's a Scottish allotment app — plot planning, seed tracking, compost monitoring, gardening advice from an AI that understands "full sun" means something different at 56°N. The cadence follows the gardening calendar: the features that matter in March (sowing windows) are different from the ones that matter in August (harvest, blight watch). The codebase grows in chapters, with the year telling it what to build next.
+votescot is ephemeral — an open-source vote compass built for the 2026 Scottish Parliament election. The relevance window is narrow; the code has to be solid for the duration, but the lifecycle has a built-in end.
 
-votescot is ephemeral. An open-source vote compass for the 2026 Scottish Parliament election: take a short quiz, see which parties and candidates align with your views. The relevance window is narrow — the election happens, the campaign matters for a few months, then the project's job is done. The code has to be solid for the duration, but the lifecycle has a built-in end.
-
-wifisentinel is reactive. I built it quickly because a specific situation needed it — a dodgy Amsterdam Airbnb where I wanted to know what was actually on the network. What started as a one-off scanner grew into a full toolkit: multi-persona analysis, compliance scoring, RF intelligence, external reconnaissance. Reactive doesn't mean throwaway. It means the trigger was an immediate need rather than a long-term roadmap, and the project earned its continued existence after the original problem was solved.
+wifisentinel is reactive — built quickly because a specific situation needed it (a dodgy Amsterdam Airbnb where I wanted to know what was actually on the network). What started as a one-off grew into a real toolkit once the original problem was solved.
 
 ## Match the Harness to the Cadence
 
-The harness from Article 2 — CLAUDE.md, the research-then-spike loop, full QA gates, ADRs for every architectural decision — is the right shape for a 7-year project with thousands of users. It's the wrong shape for a 1-month vote compass. Applying maximum process to an ephemeral codebase is overhead masquerading as rigour.
-
-But "less harness" doesn't mean "no harness." votescot still has CI, still has linting, still gets manual review on every diff. The shape is right-sized: the standards that protect a long-lived codebase against future-self confusion don't apply when the codebase has no future-self to confuse. The standards that protect users from broken behaviour apply at every cadence, because users don't care about your lifecycle.
-
-A seasonal app needs harness that survives the off-season — the project sits idle for months, the maintainer comes back fresh in March, the code has to make sense to someone who hasn't touched it since the previous October. An ephemeral app needs harness that doesn't slow you down during the only window that matters. A reactive build needs harness that can grow with the project if it turns out to have a life beyond its trigger. The discipline is sizing the harness to the lifecycle, not applying maximum ceremony everywhere.
+The full harness from Article 2 is right for a 7-year project and wrong for a 1-month vote compass — maximum process on an ephemeral codebase is overhead masquerading as rigour. But "less harness" isn't "no harness": votescot still has CI, linting, and manual review on every diff. The standards that protect users from broken behaviour apply at every cadence; the ones that protect a long-lived codebase against future-self confusion don't apply when there's no future-self to confuse. The discipline is sizing the harness to the lifecycle, not applying maximum ceremony everywhere.
 
 ## The Death Star Is Still Real
 
-The standing reminder in software is that bugs hide in complexity. Build something simpler than you think you need, because every line you add is a line that can go wrong. AI doesn't repeal that rule. It makes it more pressing.
+Bugs hide in complexity. AI doesn't repeal that rule — it makes it more pressing. When the cost of writing code drops, only the writing cost drops, not the reading, debugging, or retirement cost. The temptation to keep adding is greater than ever, which means saying "no, that's a Death Star" matters more, not less. Across cadences it shows up differently — "ten years of maintenance" on a long-lived project, "too clever for six weeks" on an ephemeral one — but it's the same reminder.
 
-When the cost of writing code drops, the cost of accumulating complexity drops too — but only the writing cost, not the reading cost, the debugging cost, or the cost of having to retire a feature later. AI lets you ship more, which means the temptation to keep adding is greater than it's ever been. The discipline of saying "no, that's a Death Star" matters more, not less.
+## Signals Are the Constraint
 
-Across cadences, the reminder shows up differently. On a long-lived project, it's "this feature would commit us to ten years of maintenance." On a seasonal one, it's "this complexity will be confusing when I come back in February." On an ephemeral one, it's "this is too clever for a codebase that has six weeks to live." On a reactive build, it's "the trigger was specific; don't gold-plate it because you can." Same reminder, different shapes.
-
-## Signals Are the Actual Constraint
-
-Once you have AI assistance and right-sized harness for each cadence, the bottleneck shifts. It's not how much code you can ship — that's solved. It's whether you can tell, in time, when something has gone wrong.
-
-Tests are signal. CI is signal. Manual review is signal. ADRs are signal about decisions. Logging, metrics, error tracking, user reports — all of them are signal about what the code is actually doing in the world. The harness exists to produce signal; the workflow exists to act on it. The journey of running any system is the same one any maintainer has always known: build trust with data, add hardness as you go, simplify or remove what stops earning its place. AI accelerates the cycles, which means signal quality has to keep up.
-
-Across cadences, signal needs differ. A long-lived project needs deep historical signal — trends, regression detection, alarm fatigue management. A seasonal app needs signal that catches up after dormancy — what changed in the ecosystem while you weren't looking. An ephemeral project needs signal that's loud and immediate, because there's no second chance. A reactive build needs signal that distinguishes "the trigger is still valid" from "this has become its own thing." The signal layer is what scales across all of them. Skimping on it is what turns AI-assisted productivity into AI-amplified mess.
-
-## What Dies Teaches You Too
-
-{/* PLACEHOLDER — needs specific failed-project examples and the lesson each one taught. The repo-butler portfolio currently shows zero archived repos, so these stories live in personal memory rather than the dashboard. */}
-
-Some projects don't make it past the first cadence. They're the ones I learned the most from — the ones where the harness was wrong, or the trigger faded, or I tried to apply long-lived discipline to something that wanted to be ephemeral.
+With AI assistance and right-sized harness, the bottleneck shifts. It's no longer how much code you can ship — that's solved. It's whether you can tell, in time, when something has gone wrong. Tests are signal. CI is signal. Manual review is signal. ADRs are signal about decisions. The harness exists to produce signal; the workflow exists to act on it. The journey is the same one any maintainer has always known: build trust with data, add hardness as you go, simplify or remove what stops earning its place. AI accelerates the cycles, so signal quality has to keep up. Skimping on it is what turns AI-assisted productivity into AI-amplified mess.
 
 ## Closing Thought
 
-Article 1 covered what AI changes about maintaining an open-source project. Article 2 was the practical workflow for one long-lived project. This one is about how the same discipline scales across very different lifecycles — long-lived, seasonal, ephemeral, reactive. The harness bends, the cadence dictates the shape, and signals become the thing you optimise for.
-
-The journey isn't finished. The harness is still evolving, the cadence taxonomy will probably need new categories as the portfolio grows, and the Death Star will keep being a temptation. None of that changes with AI assistance. What changes is how fast you can move through the cycles, and whether your signal quality keeps up with your speed.
+Same discipline, very different lifecycles. The harness bends, the cadence dictates the shape, and signals become the thing you optimise for. The journey isn't finished — the cadence taxonomy will need new categories, and the Death Star will keep being a temptation. What changes is how fast you can move through the cycles, and whether your signal quality keeps up with your speed.

--- a/src/content/articles/en/ai-assisted-open-source-cadences.mdx
+++ b/src/content/articles/en/ai-assisted-open-source-cadences.mdx
@@ -1,6 +1,6 @@
 ---
 title: "AI-Assisted Open Source: Cadences and Signals"
-description: "What changes when you run several projects at different speeds — long-lived, seasonal, ephemeral, reactive. The discipline is the same; the harness has to bend with the lifecycle, and signals become the actual constraint."
+description: "What changes when you run several projects at different speeds: long-lived, seasonal, ephemeral, reactive. The discipline is the same; the harness has to bend with the lifecycle, and signals become the actual constraint."
 publishedDate: 2026-03-18
 tags: ["AI", "Open Source", "Software Development", "Teams for Linux"]
 draft: true
@@ -8,30 +8,30 @@ draft: true
 
 ## From One Project to Several
 
-The [first article](/en/articles/ai-assisted-open-source-maintenance) asked what AI changes about maintaining an open-source project, through the lens of one 7-year codebase. The [second](/en/articles/ai-assisted-open-source-workflow) was the workflow that keeps it going. Both stayed inside a single long-lived cadence. This one steps out of that frame: AI assistance makes running several projects in parallel — at different speeds — actually feasible, and that changes what the workflow has to handle.
+The [first article](/en/articles/ai-assisted-open-source-maintenance) asked what AI changes about maintaining an open-source project, through the lens of one 7-year codebase. The [second](/en/articles/ai-assisted-open-source-workflow) was the workflow that keeps it going. Both stayed inside a single long-lived cadence. This one steps out of that frame: AI assistance makes running several projects in parallel, at different speeds, actually feasible, and that changes what the workflow has to handle.
 
 ## Four Cadences
 
-teams-for-linux is the long-lived one: seven years of history, thousands of users, the full harness.
+teams-for-linux is the long-lived one: seven years of history, hundreds of thousands of active users, the full harness.
 
-bonnie-wee-plot is seasonal — a Scottish allotment app where the features that matter in March (sowing windows) are different from the ones that matter in August (harvest, blight watch). The codebase grows in chapters, with the gardening year telling it what to build next.
+bonnie-wee-plot is seasonal, a Scottish allotment app where the features that matter in March (sowing windows) are different from the ones that matter in August (harvest, blight watch). The codebase grows in chapters, with the gardening year telling it what to build next.
 
-votescot is ephemeral — an open-source vote compass built for the 2026 Scottish Parliament election. The relevance window is narrow; the code has to be solid for the duration, but the lifecycle has a built-in end.
+votescot is ephemeral, an open-source vote compass built for the 2026 Scottish Parliament election. The relevance window is narrow; the code has to be solid for the duration, but the lifecycle has a built-in end.
 
-wifisentinel is reactive — built quickly because a specific situation needed it (a dodgy Amsterdam Airbnb where I wanted to know what was actually on the network). What started as a one-off grew into a real toolkit once the original problem was solved.
+wifisentinel is reactive, built quickly because a specific situation needed it (a dodgy Amsterdam Airbnb where I wanted to know what was actually on the network). What started as a one-off grew into a real toolkit once the original problem was solved.
 
 ## Match the Harness to the Cadence
 
-The full harness from Article 2 is right for a 7-year project and wrong for a 1-month vote compass — maximum process on an ephemeral codebase is overhead masquerading as rigour. But "less harness" isn't "no harness": votescot still has CI, linting, and manual review on every diff. The standards that protect users from broken behaviour apply at every cadence; the ones that protect a long-lived codebase against future-self confusion don't apply when there's no future-self to confuse. The discipline is sizing the harness to the lifecycle, not applying maximum ceremony everywhere.
+The full harness from Article 2 is right for a 7-year project and wrong for a 1-month vote compass. Maximum process on an ephemeral codebase is overhead masquerading as rigour. But "less harness" isn't "no harness": votescot still has CI, linting, and manual review on every diff. The standards that protect users from broken behaviour apply at every cadence; the ones that protect a long-lived codebase against future-self confusion don't apply when there's no future-self to confuse. The discipline is sizing the harness to the lifecycle, not applying maximum ceremony everywhere.
 
 ## The Death Star Is Still Real
 
-Bugs hide in complexity. AI doesn't repeal that rule — it makes it more pressing. When the cost of writing code drops, only the writing cost drops, not the reading, debugging, or retirement cost. The temptation to keep adding is greater than ever, which means saying "no, that's a Death Star" matters more, not less. Across cadences it shows up differently — "ten years of maintenance" on a long-lived project, "too clever for six weeks" on an ephemeral one — but it's the same reminder.
+Bugs hide in complexity. AI doesn't repeal that rule; it makes it more pressing. When the cost of writing code drops, only the writing cost drops, not the reading, debugging, or retirement cost. The temptation to keep adding is greater than ever, which means saying "no, that's a Death Star" matters more, not less. Across cadences it shows up differently. "Ten years of maintenance" on a long-lived project, "too clever for six weeks" on an ephemeral one. But it's the same reminder.
 
 ## Signals Are the Constraint
 
-With AI assistance and right-sized harness, the bottleneck shifts. It's no longer how much code you can ship — that's solved. It's whether you can tell, in time, when something has gone wrong. Tests are signal. CI is signal. Manual review is signal. ADRs are signal about decisions. The harness exists to produce signal; the workflow exists to act on it. The journey is the same one any maintainer has always known: build trust with data, add hardness as you go, simplify or remove what stops earning its place. AI accelerates the cycles, so signal quality has to keep up. Skimping on it is what turns AI-assisted productivity into AI-amplified mess.
+With AI assistance and right-sized harness, the bottleneck shifts. It's no longer how much code you can ship; that's solved. It's whether you can tell, in time, when something has gone wrong. Tests are signal. CI is signal. Manual review is signal. ADRs are signal about decisions. The harness exists to produce signal; the workflow exists to act on it. The journey is the same one any maintainer has always known: build trust with data, add hardness as you go, simplify or remove what stops earning its place. AI accelerates the cycles, so signal quality has to keep up. Skimping on it is what turns AI-assisted productivity into AI-amplified mess.
 
 ## Closing Thought
 
-Same discipline, very different lifecycles. The harness bends, the cadence dictates the shape, and signals become the thing you optimise for. The journey isn't finished — the cadence taxonomy will need new categories, and the Death Star will keep being a temptation. What changes is how fast you can move through the cycles, and whether your signal quality keeps up with your speed.
+Same discipline, very different lifecycles. The harness bends, the cadence dictates the shape, and signals become the thing you optimise for. The journey isn't finished. The cadence taxonomy will need new categories, and the Death Star will keep being a temptation. What changes is how fast you can move through the cycles, and whether your signal quality keeps up with your speed.

--- a/src/content/articles/en/ai-assisted-open-source-cadences.mdx
+++ b/src/content/articles/en/ai-assisted-open-source-cadences.mdx
@@ -1,0 +1,59 @@
+---
+title: "AI-Assisted Open Source: Cadences and Signals"
+description: "What changes when you run several projects at different speeds — long-lived, seasonal, ephemeral, reactive. The discipline is the same; the harness has to bend with the lifecycle, and signals become the actual constraint."
+publishedDate: 2026-03-18
+tags: ["AI", "Open Source", "Software Development", "Teams for Linux"]
+draft: true
+---
+
+## From One Project to Several
+
+The [first article in this series](/en/articles/ai-assisted-open-source-maintenance) asked what AI changes about maintaining an open-source project, and answered it through the lens of teams-for-linux — one codebase, seven years old, single maintainer. The [second article](/en/articles/ai-assisted-open-source-workflow) was the practical workflow that keeps it going. Both stayed inside the long-lived cadence.
+
+This one steps out of that frame. AI assistance doesn't just make a single long-lived project more sustainable; it makes running several projects in parallel — at different speeds, with different lifecycles — actually feasible. That changes what the workflow has to handle.
+
+## Four Cadences I Work In
+
+teams-for-linux is the long-lived one. Seven years of history, thousands of users, the full harness — CLAUDE.md, ADRs, QA gates, careful release judgement. Article 2 was about this cadence in detail.
+
+bonnie-wee-plot is seasonal. It's a Scottish allotment app — plot planning, seed tracking, compost monitoring, gardening advice from an AI that understands "full sun" means something different at 56°N. The cadence follows the gardening calendar: the features that matter in March (sowing windows) are different from the ones that matter in August (harvest, blight watch). The codebase grows in chapters, with the year telling it what to build next.
+
+votescot is ephemeral. An open-source vote compass for the 2026 Scottish Parliament election: take a short quiz, see which parties and candidates align with your views. The relevance window is narrow — the election happens, the campaign matters for a few months, then the project's job is done. The code has to be solid for the duration, but the lifecycle has a built-in end.
+
+wifisentinel is reactive. I built it quickly because a specific situation needed it — a dodgy Amsterdam Airbnb where I wanted to know what was actually on the network. What started as a one-off scanner grew into a full toolkit: multi-persona analysis, compliance scoring, RF intelligence, external reconnaissance. Reactive doesn't mean throwaway. It means the trigger was an immediate need rather than a long-term roadmap, and the project earned its continued existence after the original problem was solved.
+
+## Match the Harness to the Cadence
+
+The harness from Article 2 — CLAUDE.md, the research-then-spike loop, full QA gates, ADRs for every architectural decision — is the right shape for a 7-year project with thousands of users. It's the wrong shape for a 1-month vote compass. Applying maximum process to an ephemeral codebase is overhead masquerading as rigour.
+
+But "less harness" doesn't mean "no harness." votescot still has CI, still has linting, still gets manual review on every diff. The shape is right-sized: the standards that protect a long-lived codebase against future-self confusion don't apply when the codebase has no future-self to confuse. The standards that protect users from broken behaviour apply at every cadence, because users don't care about your lifecycle.
+
+A seasonal app needs harness that survives the off-season — the project sits idle for months, the maintainer comes back fresh in March, the code has to make sense to someone who hasn't touched it since the previous October. An ephemeral app needs harness that doesn't slow you down during the only window that matters. A reactive build needs harness that can grow with the project if it turns out to have a life beyond its trigger. The discipline is sizing the harness to the lifecycle, not applying maximum ceremony everywhere.
+
+## The Death Star Is Still Real
+
+The standing reminder in software is that bugs hide in complexity. Build something simpler than you think you need, because every line you add is a line that can go wrong. AI doesn't repeal that rule. It makes it more pressing.
+
+When the cost of writing code drops, the cost of accumulating complexity drops too — but only the writing cost, not the reading cost, the debugging cost, or the cost of having to retire a feature later. AI lets you ship more, which means the temptation to keep adding is greater than it's ever been. The discipline of saying "no, that's a Death Star" matters more, not less.
+
+Across cadences, the reminder shows up differently. On a long-lived project, it's "this feature would commit us to ten years of maintenance." On a seasonal one, it's "this complexity will be confusing when I come back in February." On an ephemeral one, it's "this is too clever for a codebase that has six weeks to live." On a reactive build, it's "the trigger was specific; don't gold-plate it because you can." Same reminder, different shapes.
+
+## Signals Are the Actual Constraint
+
+Once you have AI assistance and right-sized harness for each cadence, the bottleneck shifts. It's not how much code you can ship — that's solved. It's whether you can tell, in time, when something has gone wrong.
+
+Tests are signal. CI is signal. Manual review is signal. ADRs are signal about decisions. Logging, metrics, error tracking, user reports — all of them are signal about what the code is actually doing in the world. The harness exists to produce signal; the workflow exists to act on it. The journey of running any system is the same one any maintainer has always known: build trust with data, add hardness as you go, simplify or remove what stops earning its place. AI accelerates the cycles, which means signal quality has to keep up.
+
+Across cadences, signal needs differ. A long-lived project needs deep historical signal — trends, regression detection, alarm fatigue management. A seasonal app needs signal that catches up after dormancy — what changed in the ecosystem while you weren't looking. An ephemeral project needs signal that's loud and immediate, because there's no second chance. A reactive build needs signal that distinguishes "the trigger is still valid" from "this has become its own thing." The signal layer is what scales across all of them. Skimping on it is what turns AI-assisted productivity into AI-amplified mess.
+
+## What Dies Teaches You Too
+
+{/* PLACEHOLDER — needs specific failed-project examples and the lesson each one taught. The repo-butler portfolio currently shows zero archived repos, so these stories live in personal memory rather than the dashboard. */}
+
+Some projects don't make it past the first cadence. They're the ones I learned the most from — the ones where the harness was wrong, or the trigger faded, or I tried to apply long-lived discipline to something that wanted to be ephemeral.
+
+## Closing Thought
+
+Article 1 covered what AI changes about maintaining an open-source project. Article 2 was the practical workflow for one long-lived project. This one is about how the same discipline scales across very different lifecycles — long-lived, seasonal, ephemeral, reactive. The harness bends, the cadence dictates the shape, and signals become the thing you optimise for.
+
+The journey isn't finished. The harness is still evolving, the cadence taxonomy will probably need new categories as the portfolio grows, and the Death Star will keep being a temptation. None of that changes with AI assistance. What changes is how fast you can move through the cycles, and whether your signal quality keeps up with your speed.

--- a/src/content/articles/en/ai-assisted-open-source-maintenance.mdx
+++ b/src/content/articles/en/ai-assisted-open-source-maintenance.mdx
@@ -62,15 +62,13 @@ With AI tooling, I can keep up with security patches, Electron upgrades, user re
 
 The alternative to AI-assisted maintenance isn't "write everything by hand." It's "let issues pile up and eventually walk away." For solo open-source maintainers, AI is a sustainability tool, not a shortcut.
 
-## The Visible Markers
+## Working in the Open
 
-Every AI-assisted commit in the repository carries a `Co-authored-by` tag. That's transparency, not confession.
+Every AI-assisted commit in the repository carries a `Co-authored-by` tag. The CLAUDE.md file is checked into the repo where anyone can read it. This isn't about making a statement — it's about learning.
 
-The CLAUDE.md file is checked into the repo where anyone can read it. I could hide all of this easily. Strip the co-author tags, remove the configuration file, and nobody would know. I chose not to because being open about tooling is the right thing to do.
+I want to understand what works. Which kinds of AI-assisted changes get accepted smoothly by the community? Which ones generate friction? Does visible AI involvement change how people engage with the project? These are open questions, and the only way to answer them is to be open about the process.
 
-The irony is that hiding AI usage is trivially easy and almost certainly widespread. The projects that are transparent about it are the ones getting scrutinised, while projects that hide it face no questions at all. That incentive structure is backwards.
-
-Transparency about AI usage should be normalised, not penalised. The conversation should be about outcomes — does the software work, is it maintained, are users served well — not about which tools the maintainer used to get there.
+Whether other maintainers choose to show or hide their AI usage is their business. I'm not interested in that debate. What I'm interested in is running an honest experiment: maintain a project openly with AI tooling, see what the community response actually is, and share what I learn.
 
 ## Closing Thought
 

--- a/src/content/articles/en/ai-assisted-open-source-maintenance.mdx
+++ b/src/content/articles/en/ai-assisted-open-source-maintenance.mdx
@@ -3,7 +3,7 @@ title: "AI-Assisted Open Source: What Changes and What Doesn't"
 description: "How AI tooling fits into maintaining a 7-year open-source project — what it accelerates, what it can't replace, and why the CLAUDE.md file exists."
 publishedDate: 2026-03-03
 tags: ["AI", "Open Source", "Software Development", "Teams for Linux"]
-draft: false
+draft: true
 ---
 
 ## The Project Predates the Tools

--- a/src/content/articles/en/ai-assisted-open-source-maintenance.mdx
+++ b/src/content/articles/en/ai-assisted-open-source-maintenance.mdx
@@ -8,7 +8,7 @@ draft: true
 
 ## The Project Predates the Tools
 
-teams-for-linux started in 2018. That's more than five years before any AI coding tool existed. I built an Electron wrapper for Microsoft Teams because Microsoft dropped official Linux support and thousands of developers needed a working client. The project grew organically to over 4,400 stars, 315 forks, and 30 contributors over the years.
+teams-for-linux started in 2018, years before AI coding tools entered the mainstream. I built an Electron wrapper for Microsoft Teams because there was no official Linux client at the time — Microsoft wouldn't ship one until late 2019, and when they eventually retired it in 2023, teams-for-linux became the de facto option. The project grew organically to over 4,500 stars, 320 forks, and dozens of contributors over the years.
 
 AI adoption came much later. It's a tool choice I made to keep up with the demands of maintaining a project this size, not the origin story. The timeline matters because people sometimes look at a repository, see signs of AI tooling, and assume the whole thing was generated. It wasn't. The project has seven years of history, community, and hard-won architectural decisions behind it.
 

--- a/src/content/articles/en/ai-assisted-open-source-maintenance.mdx
+++ b/src/content/articles/en/ai-assisted-open-source-maintenance.mdx
@@ -3,7 +3,7 @@ title: "AI-Assisted Open Source: What Changes and What Doesn't"
 description: "How AI tooling fits into maintaining a 7-year open-source project — what it accelerates, what it can't replace, and why the CLAUDE.md file exists."
 publishedDate: 2026-03-03
 tags: ["AI", "Open Source", "Software Development", "Teams for Linux"]
-draft: true
+draft: false
 ---
 
 ## The Project Predates the Tools
@@ -19,6 +19,8 @@ When people spotted the CLAUDE.md file in the repository, some assumed it meant 
 CLAUDE.md is a configuration file, much like `.editorconfig` or `tsconfig.json`. It tells the AI tool how to behave in this specific codebase. It documents architectural decisions, module boundaries, and critical invariants — like the `trayIconRenderer`/`mqttStatusMonitor` initialisation requirement that has been accidentally broken multiple times by contributors who didn't know about the dependency.
 
 The file encodes project-specific knowledge so the AI tool respects existing patterns instead of inventing new ones. Every codebase has unwritten rules. CLAUDE.md makes them explicit. It's not a sign of AI authorship. It's a sign of AI discipline.
+
+In the [companion article on the actual workflow](/en/articles/ai-assisted-open-source-workflow), I go deeper into how this file shapes every interaction — from research spikes to dependency upgrades to feature implementation.
 
 ## What AI Actually Accelerates
 
@@ -45,6 +47,8 @@ Architectural decisions sit in the same category. When to refactor versus when t
 Release judgement is more nuanced than it sounds. Is this build ready? Should I batch more fixes first? Is the Wayland fix stable enough to ship, or does it need another week of testing? These decisions require context that no tool has access to.
 
 Understanding upstream changes is a constant challenge. The Teams web app changes without notice, and defensive coding against those changes requires deep domain knowledge about what Microsoft is likely to do and how their platform evolves. AI doesn't know what Microsoft shipped last Tuesday.
+
+Some problems are simply unfixable, regardless of tooling. When Microsoft changes their web app in ways that break third-party clients, no amount of AI-assisted coding can produce a workaround that doesn't exist. The maintainer has to recognise when a problem has no good solution, communicate that honestly to users, and move on. AI will keep trying to generate fixes for things that can't be fixed.
 
 And then there's saying no to feature requests. That's perhaps the hardest part of maintaining a popular project, and it's entirely a human skill.
 
@@ -75,3 +79,5 @@ The interesting question isn't "did AI write this code?"
 It's whether the project works, whether it's maintained, and whether users are served well. By those measures, AI tooling is doing exactly what it should — keeping a useful project alive and responsive when the alternative is slow decay.
 
 In [The AI Automation Trap](/en/articles/the-ai-automation-trap), I wrote about how AI removed the building constraint but didn't remove the deciding constraint. This project is the lived example. AI handles the building. The deciding, the maintaining, and the caring about users — that's still entirely human. And it always will be.
+
+If you want to see how this actually works day-to-day — the specific workflow, the tooling, the quality gates — read [AI-Assisted Open Source: The Workflow](/en/articles/ai-assisted-open-source-workflow).

--- a/src/content/articles/en/ai-assisted-open-source-maintenance.mdx
+++ b/src/content/articles/en/ai-assisted-open-source-maintenance.mdx
@@ -8,7 +8,7 @@ draft: true
 
 ## The Project Predates the Tools
 
-teams-for-linux started in 2018, years before AI coding tools entered the mainstream. I built an Electron wrapper for Microsoft Teams because there was no official Linux client at the time — Microsoft wouldn't ship one until late 2019, and when they eventually retired it in 2023, teams-for-linux became the de facto option. The project grew organically to over 4,500 stars, 320 forks, and dozens of contributors over the years.
+teams-for-linux started in 2018, years before AI coding tools entered the mainstream. I built an Electron wrapper for Microsoft Teams because there was no official Linux client at the time — Microsoft wouldn't ship one until late 2019, and when they eventually retired it in late 2022, teams-for-linux became the de facto option. The project has grown organically to over 4,600 stars, 330 forks, and dozens of contributors over the years (numbers as of writing).
 
 AI adoption came much later. It's a tool choice I made to keep up with the demands of maintaining a project this size, not the origin story. The timeline matters because people sometimes look at a repository, see signs of AI tooling, and assume the whole thing was generated. It wasn't. The project has seven years of history, community, and hard-won architectural decisions behind it.
 

--- a/src/content/articles/en/ai-assisted-open-source-maintenance.mdx
+++ b/src/content/articles/en/ai-assisted-open-source-maintenance.mdx
@@ -1,6 +1,6 @@
 ---
 title: "AI-Assisted Open Source: What Changes and What Doesn't"
-description: "How AI tooling fits into maintaining a 7-year open-source project — what it accelerates, what it can't replace, and why the CLAUDE.md file exists."
+description: "How AI tooling fits into maintaining a 7-year open-source project: what it accelerates, what it can't replace, and why the CLAUDE.md file exists."
 publishedDate: 2026-03-03
 tags: ["AI", "Open Source", "Software Development", "Teams for Linux"]
 draft: true
@@ -8,28 +8,30 @@ draft: true
 
 ## The Project Predates the Tools
 
-teams-for-linux started in 2018, years before AI coding tools became mainstream. I built an Electron wrapper because Microsoft had no Linux client; they shipped a preview in late 2019 and retired it in late 2022, at which point this project became the de facto option. It has grown to over 4,600 stars and 330 forks as of writing. AI tooling came later — a sustainability choice for a solo maintainer keeping up with a project this size, not the origin story.
+When teams-for-linux started in 2018, AI coding tools weren't on anyone's mind. We were writing the code, writing the tests, checking the coverage. The usual. The project itself was born out of necessity: Microsoft had no Linux client, and their web app didn't deliver notifications, which made it fairly useless as a chat app.
 
-## What CLAUDE.md Actually Is
+In late 2019 Microsoft finally shipped an official Linux preview, so the project went on the back burner and I took the chance to smell the roses. That lasted until late 2022, when Microsoft retired the client and a lot of people came back here. Now it's 2026 and, as of writing, the repo has more than 4,000 stars and 300 forks.
 
-CLAUDE.md is a configuration file, like `.editorconfig` or `tsconfig.json`. It tells the AI how to behave in this specific codebase: architectural invariants, module boundaries, known footguns. The `trayIconRenderer` must initialise before `mqttStatusMonitor`, for example — a dependency contributors have broken more than once without knowing it existed. Every codebase has unwritten rules; CLAUDE.md makes them explicit. It's a sign of discipline, not authorship. [The Workflow](/en/articles/ai-assisted-open-source-workflow) covers how this file shapes day-to-day work.
+For a solo maintainer on a project this size, AI-assisted coding isn't really a question of *whether*. It's a question of *how to do it well*. This article sets out the principles; the rest of the series is where I work through it in practice.
 
 ## What AI Accelerates, What It Can't
 
-AI handles the work that would otherwise burn out a solo maintainer: implementation of well-defined features, dependency upgrades and security patches (which the npm ecosystem produces multiple times a week), exploring unfamiliar APIs, and triaging issues at scale. I also run a Gemini-powered triage bot so I can focus on issues that actually need a human.
+AI handles the work that would otherwise burn out a solo maintainer: implementation of well-defined features, dependency upgrades and security patches (which the npm ecosystem produces multiple times a week), exploring unfamiliar APIs, and triaging issues at scale. The exact shape keeps evolving. I'm still experimenting with what to delegate and how, with tools like [repo-butler](https://github.com/IsmaelMartinez/repo-butler) watching portfolio health alongside the project itself. The aim isn't only to save my time; it's to save the reporters' time too, and make the tool better for everyone.
 
-What AI can't touch is the hard part of maintaining an open-source project, and it never could. Deciding what to build (and what to refuse), reading the community when users push back on update frequency, drawing module boundaries, judging when a release is ready, recognising when an upstream change has no workaround — these are human calls. AI will happily generate fixes for problems that have no fix; recognising that and communicating honestly with users is still entirely human work.
+What AI can't touch, at least not yet, is the part that runs on taste. Deciding what to build (and what to refuse), prioritising within the community, understanding where the boundaries should sit, judging when a release is ready, knowing when an upstream change has no workaround. These are human calls. AI is happy to generate fixes for problems that have no fix, and it will tell you it's right with the same conviction whether it actually is or isn't. Navigating that, and communicating honestly with users, is where the human work lives.
 
 ## Solo Maintainer Reality
 
-teams-for-linux is one maintainer and thousands of users. Without AI tooling the math doesn't work — security patches sit in the queue, releases slow, the backlog grows faster than one person can address it, and the project eventually gets abandoned. That's the default outcome for popular single-maintainer projects. With AI tooling I can keep up with patches, upgrades, and issues, and still ship new features. The alternative isn't "write everything by hand" — it's "let issues pile up and walk away." For solo maintainers, AI is a sustainability tool, not a shortcut.
+teams-for-linux has plenty of contributors, but at any given time there's only ever been one maintainer. The baton has been passed a couple of times, most notably when Microsoft shipped their own Linux client and the project went into maintenance mode for a while. Today I'm carrying it, alongside hundreds of thousands of active users.
+
+That ratio is the core challenge. Even with AI tooling, keeping up with issues, PRs, releases, and security patches is a daily task. And that's on top of having a job and a life. Without AI tooling the math doesn't work at all: the backlog grows faster than one person can address it, releases slow, and the project eventually gets abandoned. That's the default outcome for popular single-maintainer projects.
+
+For solo maintainers, AI isn't a shortcut. It's the difference between keeping going and walking away.
 
 ## Working in the Open
 
-Every AI-assisted commit carries a `Co-authored-by` tag. CLAUDE.md sits in the repository for anyone to read. This isn't about making a statement — it's about learning which AI-assisted changes get accepted smoothly, which generate friction, and whether visible AI involvement changes how people engage. Honest answers need an honest process. What other maintainers do is their business.
+Every AI-assisted commit carries a `Co-authored-by` tag. The configuration that drives the AI's behaviour on this codebase, CLAUDE.md, sits in the repository for anyone to read. I could just as easily hide it. Keep the prompts in personal folders, leave the tags off, never mention which parts the AI wrote. But why? AI assistance isn't a question of *if* any more, it's a question of *how*. It's a tool, and treating it as such means being open about how it's used.
 
-## Closing Thought
+What's interesting is what changes when a mature open-source project picks up these tools. What becomes possible, how much more work a solo maintainer can carry, what gets easier and what stays hard. The next article in the series, [The Workflow](/en/articles/ai-assisted-open-source-workflow), is the practical day-to-day shape of that.
 
-The interesting question isn't "did AI write this?" It's whether the project works, whether it's maintained, and whether users are served well. In [The AI Automation Trap](/en/articles/the-ai-automation-trap), I wrote about how AI removed the building constraint but didn't remove the deciding constraint. This project is the lived example. AI handles the building. Deciding, maintaining, and caring about users — that's still human, and always will be.
-
-If you want to see how this works day-to-day, read [The Workflow](/en/articles/ai-assisted-open-source-workflow).
+And there's a trap waiting. In [The AI Automation Trap](/en/articles/the-ai-automation-trap) I wrote that AI removed the building constraint but not the deciding constraint. The more we delegate to the machine, the more complexity we can generate. That means more to maintain, more to debug, more to read. AI doesn't get you out of that loop, or any of the others. Documentation passes, rearchitecture work, observability investments, the long tail of support. None of it goes away. It just happens faster.

--- a/src/content/articles/en/ai-assisted-open-source-maintenance.mdx
+++ b/src/content/articles/en/ai-assisted-open-source-maintenance.mdx
@@ -8,74 +8,28 @@ draft: true
 
 ## The Project Predates the Tools
 
-teams-for-linux started in 2018, years before AI coding tools entered the mainstream. I built an Electron wrapper for Microsoft Teams because there was no official Linux client at the time — Microsoft wouldn't ship one until late 2019, and when they eventually retired it in late 2022, teams-for-linux became the de facto option. The project has grown organically to over 4,600 stars, 330 forks, and dozens of contributors over the years (numbers as of writing).
-
-AI adoption came much later. It's a tool choice I made to keep up with the demands of maintaining a project this size, not the origin story. The timeline matters because people sometimes look at a repository, see signs of AI tooling, and assume the whole thing was generated. It wasn't. The project has seven years of history, community, and hard-won architectural decisions behind it.
+teams-for-linux started in 2018, years before AI coding tools became mainstream. I built an Electron wrapper because Microsoft had no Linux client; they shipped a preview in late 2019 and retired it in late 2022, at which point this project became the de facto option. It has grown to over 4,600 stars and 330 forks as of writing. AI tooling came later — a sustainability choice for a solo maintainer keeping up with a project this size, not the origin story.
 
 ## What CLAUDE.md Actually Is
 
-When people spotted the CLAUDE.md file in the repository, some assumed it meant the project was AI-authored. That's a misunderstanding of what the file does.
+CLAUDE.md is a configuration file, like `.editorconfig` or `tsconfig.json`. It tells the AI how to behave in this specific codebase: architectural invariants, module boundaries, known footguns. The `trayIconRenderer` must initialise before `mqttStatusMonitor`, for example — a dependency contributors have broken more than once without knowing it existed. Every codebase has unwritten rules; CLAUDE.md makes them explicit. It's a sign of discipline, not authorship. [The Workflow](/en/articles/ai-assisted-open-source-workflow) covers how this file shapes day-to-day work.
 
-CLAUDE.md is a configuration file, much like `.editorconfig` or `tsconfig.json`. It tells the AI tool how to behave in this specific codebase. It documents architectural decisions, module boundaries, and critical invariants — like the `trayIconRenderer`/`mqttStatusMonitor` initialisation requirement that has been accidentally broken multiple times by contributors who didn't know about the dependency.
+## What AI Accelerates, What It Can't
 
-The file encodes project-specific knowledge so the AI tool respects existing patterns instead of inventing new ones. Every codebase has unwritten rules. CLAUDE.md makes them explicit. It's not a sign of AI authorship. It's a sign of AI discipline.
+AI handles the work that would otherwise burn out a solo maintainer: implementation of well-defined features, dependency upgrades and security patches (which the npm ecosystem produces multiple times a week), exploring unfamiliar APIs, and triaging issues at scale. I also run a Gemini-powered triage bot so I can focus on issues that actually need a human.
 
-In the [companion article on the actual workflow](/en/articles/ai-assisted-open-source-workflow), I go deeper into how this file shapes every interaction — from research spikes to dependency upgrades to feature implementation.
-
-## What AI Actually Accelerates
-
-The tasks AI handles well are the ones that would otherwise burn out a solo maintainer.
-
-Implementation of well-understood features is the obvious one. Once I've decided what to build and how it should work, the actual coding — the mechanical translation of intent into code — goes faster with AI assistance. Boilerplate, test scaffolding, and documentation updates fall into the same category. They're necessary work, but they don't require creative judgement.
-
-Dependency upgrades and security patch responses are where the time savings really add up. The npm ecosystem pushes security advisories multiple times a week. Each one needs evaluation, patching, testing, and release. Without tooling, that alone can consume most of a maintainer's available hours.
-
-Exploring unfamiliar APIs is another area where AI shines. Electron's API surface is vast, Wayland has its own quirks, and Linux is a full box of surprises. Having a tool that can quickly surface relevant documentation and usage patterns cuts the exploration time significantly.
-
-I also built a Gemini-powered triage bot for GitHub issues. When a project gets hundreds of issues, sorting signal from noise manually isn't sustainable. The bot handles initial categorisation so I can focus on the issues that actually need human attention.
-
-## What AI Cannot Replace
-
-The hard work of maintaining an open-source project is not writing code. It never was.
-
-Deciding what to build and what not to build requires understanding the project's direction, the community's needs, and the trade-offs of every addition. AI has no opinion on this. It will happily build whatever you ask for, whether the project needs it or not.
-
-Community management is entirely human work. When users started pushing back on update frequency — the "chill with updates" conversation — that required empathy, reading the room, and making a judgement call about release cadence. No AI tool can navigate that.
-
-Architectural decisions sit in the same category. When to refactor versus when to patch. Where to draw module boundaries. How much backwards compatibility to maintain and when to break it. These choices shape the project for years and can't be delegated to a tool that optimises for the immediate task.
-
-Release judgement is more nuanced than it sounds. Is this build ready? Should I batch more fixes first? Is the Wayland fix stable enough to ship, or does it need another week of testing? These decisions require context that no tool has access to.
-
-Understanding upstream changes is a constant challenge. The Teams web app changes without notice, and defensive coding against those changes requires deep domain knowledge about what Microsoft is likely to do and how their platform evolves. AI doesn't know what Microsoft shipped last Tuesday.
-
-Some problems are simply unfixable, regardless of tooling. When Microsoft changes their web app in ways that break third-party clients, no amount of AI-assisted coding can produce a workaround that doesn't exist. The maintainer has to recognise when a problem has no good solution, communicate that honestly to users, and move on. AI will keep trying to generate fixes for things that can't be fixed.
-
-And then there's saying no to feature requests. That's perhaps the hardest part of maintaining a popular project, and it's entirely a human skill.
+What AI can't touch is the hard part of maintaining an open-source project, and it never could. Deciding what to build (and what to refuse), reading the community when users push back on update frequency, drawing module boundaries, judging when a release is ready, recognising when an upstream change has no workaround — these are human calls. AI will happily generate fixes for problems that have no fix; recognising that and communicating honestly with users is still entirely human work.
 
 ## Solo Maintainer Reality
 
-teams-for-linux is a single-maintainer project with thousands of active users. That ratio is the core challenge.
-
-Without AI tooling, the maths doesn't work. Responding to issues takes longer. Releases happen less frequently. Security patches sit in the queue. Eventually the backlog grows faster than one person can address it, and the project gets abandoned. That's not hypothetical — it's the default outcome for popular single-maintainer projects.
-
-With AI tooling, I can keep up with security patches, Electron upgrades, user reports, and still ship new features. The tool handles the mechanical work so I can spend my limited time on the decisions and community interactions that actually require a human.
-
-The alternative to AI-assisted maintenance isn't "write everything by hand." It's "let issues pile up and eventually walk away." For solo open-source maintainers, AI is a sustainability tool, not a shortcut.
+teams-for-linux is one maintainer and thousands of users. Without AI tooling the math doesn't work — security patches sit in the queue, releases slow, the backlog grows faster than one person can address it, and the project eventually gets abandoned. That's the default outcome for popular single-maintainer projects. With AI tooling I can keep up with patches, upgrades, and issues, and still ship new features. The alternative isn't "write everything by hand" — it's "let issues pile up and walk away." For solo maintainers, AI is a sustainability tool, not a shortcut.
 
 ## Working in the Open
 
-Every AI-assisted commit in the repository carries a `Co-authored-by` tag. The CLAUDE.md file is checked into the repo where anyone can read it. This isn't about making a statement — it's about learning.
-
-I want to understand what works. Which kinds of AI-assisted changes get accepted smoothly by the community? Which ones generate friction? Does visible AI involvement change how people engage with the project? These are open questions, and the only way to answer them is to be open about the process.
-
-Whether other maintainers choose to show or hide their AI usage is their business. I'm not interested in that debate. What I'm interested in is running an honest experiment: maintain a project openly with AI tooling, see what the community response actually is, and share what I learn.
+Every AI-assisted commit carries a `Co-authored-by` tag. CLAUDE.md sits in the repository for anyone to read. This isn't about making a statement — it's about learning which AI-assisted changes get accepted smoothly, which generate friction, and whether visible AI involvement changes how people engage. Honest answers need an honest process. What other maintainers do is their business.
 
 ## Closing Thought
 
-The interesting question isn't "did AI write this code?"
+The interesting question isn't "did AI write this?" It's whether the project works, whether it's maintained, and whether users are served well. In [The AI Automation Trap](/en/articles/the-ai-automation-trap), I wrote about how AI removed the building constraint but didn't remove the deciding constraint. This project is the lived example. AI handles the building. Deciding, maintaining, and caring about users — that's still human, and always will be.
 
-It's whether the project works, whether it's maintained, and whether users are served well. By those measures, AI tooling is doing exactly what it should — keeping a useful project alive and responsive when the alternative is slow decay.
-
-In [The AI Automation Trap](/en/articles/the-ai-automation-trap), I wrote about how AI removed the building constraint but didn't remove the deciding constraint. This project is the lived example. AI handles the building. The deciding, the maintaining, and the caring about users — that's still entirely human. And it always will be.
-
-If you want to see how this actually works day-to-day — the specific workflow, the tooling, the quality gates — read [AI-Assisted Open Source: The Workflow](/en/articles/ai-assisted-open-source-workflow).
+If you want to see how this works day-to-day, read [The Workflow](/en/articles/ai-assisted-open-source-workflow).

--- a/src/content/articles/en/ai-assisted-open-source-maintenance.mdx
+++ b/src/content/articles/en/ai-assisted-open-source-maintenance.mdx
@@ -30,7 +30,7 @@ Implementation of well-understood features is the obvious one. Once I've decided
 
 Dependency upgrades and security patch responses are where the time savings really add up. The npm ecosystem pushes security advisories multiple times a week. Each one needs evaluation, patching, testing, and release. Without tooling, that alone can consume most of a maintainer's available hours.
 
-Exploring unfamiliar APIs is another area where AI shines. Electron's API surface is vast, Wayland has its own quirks, and Trusted Types introduced a whole new set of constraints. Having a tool that can quickly surface relevant documentation and usage patterns cuts the exploration time significantly.
+Exploring unfamiliar APIs is another area where AI shines. Electron's API surface is vast, Wayland has its own quirks, and Linux is a full box of surprises. Having a tool that can quickly surface relevant documentation and usage patterns cuts the exploration time significantly.
 
 I also built a Gemini-powered triage bot for GitHub issues. When a project gets hundreds of issues, sorting signal from noise manually isn't sustainable. The bot handles initial categorisation so I can focus on the issues that actually need human attention.
 

--- a/src/content/articles/en/ai-assisted-open-source-workflow.mdx
+++ b/src/content/articles/en/ai-assisted-open-source-workflow.mdx
@@ -132,7 +132,7 @@ After months of working this way, a few things stand out.
 
 **The maintainer's job shifts, but doesn't shrink.** I spend less time writing boilerplate and more time reviewing, deciding, and communicating. The total hours haven't decreased much. What changed is that those hours produce more value.
 
-**Transparency costs nothing.** Being open about AI usage hasn't hurt the project. The co-authored-by tags and the CLAUDE.md file are there for anyone to see. The users who care about outcomes — does the app work, is it maintained, are issues addressed — judge the project on those merits, not on the tools used.
+**Working in the open teaches you things.** The co-authored-by tags and the CLAUDE.md file are there for anyone to see. That visibility turns the project into a learning experiment — which AI-assisted changes land well, which ones generate friction, what the community actually cares about. You can't learn any of that if you hide the process.
 
 ## Closing Thought
 

--- a/src/content/articles/en/ai-assisted-open-source-workflow.mdx
+++ b/src/content/articles/en/ai-assisted-open-source-workflow.mdx
@@ -32,7 +32,7 @@ The file is a living document. When I discover a new invariant or a new footgun,
 
 ## The Research Phase
 
-Most non-trivial changes start with research, not coding. The workflow looks like this:
+Most non-trivial changes start with research, not coding. The full workflow looks like this:
 
 **I describe the problem.** "Users are reporting that screen sharing breaks on Wayland with the latest Electron update." Or "We need to support Trusted Types to comply with the new CSP requirements."
 
@@ -42,7 +42,9 @@ Most non-trivial changes start with research, not coding. The workflow looks lik
 
 **The agent produces a plan.** Once we understand the problem and have validated an approach through spikes, the agent writes up a structured plan: what changes are needed, which files are affected, what the risks are, and what should be tested.
 
-**I guide, then the agent executes.** I review the plan, adjust priorities, flag risks the agent missed, and give the go-ahead. Only then does actual implementation begin. This sequence — research, spike, plan, guide — is non-negotiable. Skipping straight to implementation is how you get code that solves the wrong problem.
+**I guide, then the agent executes.** I review the plan, adjust priorities, flag risks the agent missed, and give the go-ahead. Only then does actual implementation begin.
+
+Not every change needs the full sequence. A straightforward bug fix might skip the spike entirely and go straight from investigation to implementation. A complex Electron upgrade might need multiple rounds of spikes across several sessions. The process adapts to the problem. What doesn't change is that I understand what's happening before committing to an approach.
 
 ## Dependency Upgrades
 
@@ -69,6 +71,30 @@ When a feature gets the green light, the implementation flow follows a consisten
 **Tests alongside code.** The agent writes tests as part of implementation, not as an afterthought. The CLAUDE.md file specifies the testing conventions, so the tests follow the project's existing patterns.
 
 **Review everything.** Every piece of AI-generated code gets read. Not skimmed — read. I'm looking for subtle issues: does this respect the module boundaries? Does it handle the Electron edge cases? Does it maintain backwards compatibility where needed? The AI produces good code most of the time, but "most of the time" isn't good enough for a project with thousands of users.
+
+## Keeping the Context Clean
+
+When an implementation is done, I follow a traditional practice: the outcome gets stored as an ADR (Architecture Decision Record). The research document that led to it gets deleted.
+
+This might sound wasteful — why throw away research? — but it's deliberate. The research is always recoverable from git history if I need it. What matters is keeping the current context clean. If old research documents pile up in the repository, the AI reads them and gets confused about what's current versus what's historical. It starts referencing outdated spike results or superseded plans.
+
+The ADR captures the decision and its rationale. That's what future sessions need. The messy path that got there — the dead ends, the discarded spikes, the abandoned approaches — is noise once the decision is made. Git remembers it. The working directory doesn't need to.
+
+## Session Types
+
+The research-to-implementation workflow isn't the only kind of session I run. Maintenance involves several recurring session types, each with its own focus:
+
+**Security sessions.** Review npm audit results, evaluate advisories, patch vulnerabilities. These run frequently because the npm ecosystem never stops producing advisories.
+
+**Documentation tidy.** Update README sections, clean up inline comments that have drifted from the code, refresh CLAUDE.md with new invariants discovered since the last pass.
+
+**Metrics and health checks.** Review issue trends, contributor activity, build times, test coverage changes. Understanding the trajectory of the project, not just the current state.
+
+**Dependency upgrades.** The loop described above — detection, assessment, upgrade, test, release decision.
+
+Each session type follows the same core pattern: I set the scope, the AI executes within it, I review the results. The difference is what we're looking at, not how we work.
+
+Right now these sessions run when I get to them. I'd like to semi-automate the recurring ones — have a monthly report generated that surfaces trends, flags things that need attention, and gives me a snapshot without having to remember to look. The triage bot already does a version of this for issues. Extending that pattern to security posture, dependency freshness, and documentation drift is the natural next step.
 
 ## Handling Upstream Changes
 

--- a/src/content/articles/en/ai-assisted-open-source-workflow.mdx
+++ b/src/content/articles/en/ai-assisted-open-source-workflow.mdx
@@ -1,0 +1,117 @@
+---
+title: "AI-Assisted Open Source: The Workflow"
+description: "The practical workflow behind maintaining teams-for-linux with AI — from CLAUDE.md to research spikes, dependency upgrades, feature implementation, and quality gates."
+publishedDate: 2026-03-11
+tags: ["AI", "Open Source", "Software Development", "Teams for Linux"]
+draft: true
+---
+
+## From Principles to Practice
+
+In [the companion article](/en/articles/ai-assisted-open-source-maintenance), I covered what AI changes and what it doesn't when maintaining an open-source project. This article is the practical follow-up: the actual workflow I use day-to-day on teams-for-linux.
+
+None of this is theoretical. It's what I've settled into after months of iteration, and it keeps evolving. The core pattern is always the same: I decide, the AI executes, and I review everything before it ships.
+
+## CLAUDE.md: The Guardrails File
+
+Every interaction with the AI tool starts with CLAUDE.md. It's the first thing the agent reads when it opens the repository, and it shapes everything that follows.
+
+The file isn't long, but it's dense. It covers:
+
+**Architectural invariants.** The `trayIconRenderer` must initialise before `mqttStatusMonitor`. This dependency has been broken by contributors multiple times. Without CLAUDE.md documenting it, the AI would happily refactor one without considering the other.
+
+**Module boundaries.** Which files own which responsibilities. The AI shouldn't move functionality between modules without explicit direction, and the file makes those boundaries clear.
+
+**Build and test commands.** How to run the project, how to run tests, what the CI pipeline expects. This sounds basic, but without it the AI guesses — and guesses wrong often enough to waste time.
+
+**Commit conventions.** Co-authored-by tags, commit message format, branch naming. The AI follows these automatically because they're documented.
+
+**Known constraints.** Electron quirks, Wayland-specific behaviour, Trusted Types restrictions. These are the landmines that catch people who don't know the codebase. CLAUDE.md maps them.
+
+The file is a living document. When I discover a new invariant or a new footgun, it goes into CLAUDE.md before anything else. The investment pays off on every subsequent interaction.
+
+## The Research Phase
+
+Most non-trivial changes start with research, not coding. The workflow looks like this:
+
+**I describe the problem.** "Users are reporting that screen sharing breaks on Wayland with the latest Electron update." Or "We need to support Trusted Types to comply with the new CSP requirements."
+
+**The agent investigates.** It reads the relevant source files, checks Electron's changelog, looks at upstream issues, and surfaces what it finds. This is exploration, not implementation. The goal is understanding.
+
+**Spikes, not solutions.** For anything non-obvious, I ask for a spike — a throwaway prototype that tests a specific hypothesis. "Can we intercept the desktopCapturer call before it hits the Wayland path?" The spike tells me whether an approach is viable without committing to it.
+
+**The agent produces a plan.** Once we understand the problem and have validated an approach through spikes, the agent writes up a structured plan: what changes are needed, which files are affected, what the risks are, and what should be tested.
+
+**I guide, then the agent executes.** I review the plan, adjust priorities, flag risks the agent missed, and give the go-ahead. Only then does actual implementation begin. This sequence — research, spike, plan, guide — is non-negotiable. Skipping straight to implementation is how you get code that solves the wrong problem.
+
+## Dependency Upgrades
+
+This is where AI assistance saves the most time in absolute terms. The teams-for-linux dependency upgrade loop runs roughly like this:
+
+**Detection.** Dependabot or npm audit flags a vulnerability or outdated dependency. This happens multiple times a week.
+
+**Assessment.** The agent reads the advisory, checks what changed in the dependency, and evaluates whether it affects us. Many advisories are for code paths we don't use — the agent can identify those quickly.
+
+**Upgrade and test.** The agent bumps the version, runs the test suite, and checks for breaking changes. For minor and patch versions, this is usually straightforward. For major versions, it often triggers a research phase.
+
+**Electron upgrades are special.** Electron major versions regularly break things. The upgrade involves reading the breaking changes list, identifying which ones affect our codebase, spiking workarounds for each, and then implementing them systematically. A single Electron major upgrade can touch dozens of files. Without AI assistance, I'd budget a full weekend for each one.
+
+**Release judgement stays with me.** The agent can upgrade, test, and prepare a release. But the decision to actually ship — whether to batch more fixes, whether the timing is right, whether users need a heads-up — that's mine.
+
+## Feature Implementation
+
+When a feature gets the green light, the implementation flow follows a consistent pattern:
+
+**Clear specification first.** I describe what the feature should do, how it should behave, and — just as importantly — what it should *not* do. Scope boundaries matter. The AI will happily over-engineer if you let it.
+
+**Incremental implementation.** Large features get broken into small, reviewable chunks. Each chunk gets implemented, tested, and reviewed before moving to the next. This isn't just good practice — it's essential when working with AI, because catching a wrong direction early costs minutes, while catching it late costs hours of throwaway work.
+
+**Tests alongside code.** The agent writes tests as part of implementation, not as an afterthought. The CLAUDE.md file specifies the testing conventions, so the tests follow the project's existing patterns.
+
+**Review everything.** Every piece of AI-generated code gets read. Not skimmed — read. I'm looking for subtle issues: does this respect the module boundaries? Does it handle the Electron edge cases? Does it maintain backwards compatibility where needed? The AI produces good code most of the time, but "most of the time" isn't good enough for a project with thousands of users.
+
+## Handling Upstream Changes
+
+The Teams web app changes without notice. Microsoft doesn't publish a changelog for their web client, and defensive coding against those changes is one of the hardest parts of maintaining teams-for-linux.
+
+When something breaks, the workflow is:
+
+**Triage.** User reports come in. The agent helps categorise them: is this a regression in our code, or did Microsoft change something upstream?
+
+**Investigation.** If it's upstream, the agent examines what changed — comparing DOM structures, network requests, or API responses against what we expect. This detective work is tedious and repetitive, exactly the kind of task AI handles well.
+
+**Assessment.** Not all upstream changes can be worked around. Sometimes Microsoft removes or restricts something that we depended on, and no amount of clever coding can restore the functionality. Recognising when a problem is unfixable is a human judgement call.
+
+**Workaround or accept.** If a workaround exists, we implement it. If it doesn't, I communicate that to users honestly. The agent helps draft the response, but the decision and the tone are mine.
+
+## Quality Gates
+
+Nothing ships without passing through a set of quality gates. These aren't aspirational — they're enforced.
+
+**CI must pass.** The GitHub Actions pipeline runs linting, type checking, and the test suite. No exceptions.
+
+**Co-authored-by tags on every AI-assisted commit.** This is non-negotiable transparency. If the AI helped write it, the commit says so.
+
+**Manual review of every change.** I read every diff before it gets committed. The AI can propose changes, but I decide what actually goes into the codebase.
+
+**Release notes that explain the "why."** The agent drafts release notes, but I edit them to make sure they're useful to users — not just a list of file changes, but an explanation of what improved and why it matters.
+
+## What I've Learned
+
+After months of working this way, a few things stand out.
+
+**The workflow is the product.** The specific AI tool matters less than the process around it. Research before implementation. Spikes before commitment. Review before merge. These practices make AI assistance effective; without them, you're just generating code faster without generating better outcomes.
+
+**CLAUDE.md is the highest-leverage investment.** Every hour spent documenting invariants, boundaries, and conventions saves many hours of correcting the AI later. It's the equivalent of onboarding documentation — except the AI actually reads it every time.
+
+**The maintainer's job shifts, but doesn't shrink.** I spend less time writing boilerplate and more time reviewing, deciding, and communicating. The total hours haven't decreased much. What changed is that those hours produce more value.
+
+**Transparency costs nothing.** Being open about AI usage hasn't hurt the project. The co-authored-by tags and the CLAUDE.md file are there for anyone to see. The users who care about outcomes — does the app work, is it maintained, are issues addressed — judge the project on those merits, not on the tools used.
+
+## Closing Thought
+
+This workflow isn't a template. It's what works for a specific project with a specific maintainer. Your version will look different — different tools, different constraints, different priorities.
+
+But the underlying pattern applies broadly: humans decide, AI executes, humans review. Skip any of those steps and you're either not leveraging AI effectively or not maintaining the quality your users deserve.
+
+The [principles article](/en/articles/ai-assisted-open-source-maintenance) covers the why. This article covered the how. Together, they're the full picture of what AI-assisted open source maintenance actually looks like in practice.

--- a/src/content/articles/en/ai-assisted-open-source-workflow.mdx
+++ b/src/content/articles/en/ai-assisted-open-source-workflow.mdx
@@ -8,134 +8,44 @@ draft: true
 
 ## From Principles to Practice
 
-In [the companion article](/en/articles/ai-assisted-open-source-maintenance), I covered what AI changes and what it doesn't when maintaining an open-source project. This article is the practical follow-up: the actual workflow I use day-to-day on teams-for-linux.
+The [companion article](/en/articles/ai-assisted-open-source-maintenance) covered what AI changes when maintaining an open-source project. This one is the day-to-day workflow. The core pattern is always the same: I decide, the AI executes, I review. None of this is theoretical — it's what I've settled into after months of iteration, and it keeps evolving.
 
-None of this is theoretical. It's what I've settled into after months of iteration, and it keeps evolving. The core pattern is always the same: I decide, the AI executes, and I review everything before it ships.
+## CLAUDE.md as a Living Document
 
-## CLAUDE.md: The Guardrails File
+Every interaction starts with CLAUDE.md. The file is short but dense — architectural invariants, module boundaries, build and test commands, commit conventions, and known constraints like Electron quirks or Wayland-specific behaviour. When I discover a new invariant or footgun, it goes in before anything else. The investment pays off on every subsequent interaction.
 
-Every interaction with the AI tool starts with CLAUDE.md. It's the first thing the agent reads when it opens the repository, and it shapes everything that follows.
+## Research Before Coding
 
-The file isn't long, but it's dense. It covers:
-
-**Architectural invariants.** The `trayIconRenderer` must initialise before `mqttStatusMonitor`. This dependency has been broken by contributors multiple times. Without CLAUDE.md documenting it, the AI would happily refactor one without considering the other.
-
-**Module boundaries.** Which files own which responsibilities. The AI shouldn't move functionality between modules without explicit direction, and the file makes those boundaries clear.
-
-**Build and test commands.** How to run the project, how to run tests, what the CI pipeline expects. This sounds basic, but without it the AI guesses — and guesses wrong often enough to waste time.
-
-**Commit conventions.** Co-authored-by tags, commit message format, branch naming. The AI follows these automatically because they're documented.
-
-**Known constraints.** Electron quirks, Wayland-specific behaviour, Trusted Types restrictions. These are the landmines that catch people who don't know the codebase. CLAUDE.md maps them.
-
-The file is a living document. When I discover a new invariant or a new footgun, it goes into CLAUDE.md before anything else. The investment pays off on every subsequent interaction.
-
-## The Research Phase
-
-Most non-trivial changes start with research, not coding. The full workflow looks like this:
-
-**I describe the problem.** "Users are reporting that screen sharing breaks on Wayland with the latest Electron update." Or "We need to support Trusted Types to comply with the new CSP requirements."
-
-**The agent investigates.** It reads the relevant source files, checks Electron's changelog, looks at upstream issues, and surfaces what it finds. This is exploration, not implementation. The goal is understanding.
-
-**Spikes, not solutions.** For anything non-obvious, I ask for a spike — a throwaway prototype that tests a specific hypothesis. "Can we intercept the desktopCapturer call before it hits the Wayland path?" The spike tells me whether an approach is viable without committing to it.
-
-**The agent produces a plan.** Once we understand the problem and have validated an approach through spikes, the agent writes up a structured plan: what changes are needed, which files are affected, what the risks are, and what should be tested.
-
-**I guide, then the agent executes.** I review the plan, adjust priorities, flag risks the agent missed, and give the go-ahead. Only then does actual implementation begin.
-
-Not every change needs the full sequence. A straightforward bug fix might skip the spike entirely and go straight from investigation to implementation. A complex Electron upgrade might need multiple rounds of spikes across several sessions. The process adapts to the problem. What doesn't change is that I understand what's happening before committing to an approach.
+Most non-trivial changes start with research, not implementation. I describe the problem ("screen sharing breaks on Wayland with the latest Electron update"); the agent investigates the relevant source, changelog, and upstream issues. For anything non-obvious I ask for a spike — a throwaway prototype that tests one specific hypothesis. Once an approach is viable, the agent writes a plan; I review it, flag risks, and only then does implementation begin. Simple bug fixes skip the spike; complex Electron upgrades need several rounds. The process adapts; what doesn't change is that I understand what's happening before committing to an approach.
 
 ## Dependency Upgrades
 
-This is where AI assistance saves the most time in absolute terms. The teams-for-linux dependency upgrade loop runs roughly like this:
+This is where AI assistance saves the most time. Dependabot or npm audit flags something; the agent reads the advisory, checks what changed, and judges whether it affects us — many advisories are for code paths we don't use. Minor and patch versions are usually straightforward. Major versions often trigger a research phase. Electron majors are special: they routinely touch dozens of files, and without AI I'd budget a full weekend per upgrade. The release decision — whether to ship now or batch more fixes — stays with me.
 
-**Detection.** Dependabot or npm audit flags a vulnerability or outdated dependency. This happens multiple times a week.
+## Features and the Context-Clean Habit
 
-**Assessment.** The agent reads the advisory, checks what changed in the dependency, and evaluates whether it affects us. Many advisories are for code paths we don't use — the agent can identify those quickly.
+When a feature gets the green light, the flow is consistent: clear specification including what *not* to do, incremental implementation in reviewable chunks, tests written alongside (the AI follows the patterns documented in CLAUDE.md), and a full read of every diff. The AI produces good code most of the time, but "most of the time" isn't good enough for thousands of users.
 
-**Upgrade and test.** The agent bumps the version, runs the test suite, and checks for breaking changes. For minor and patch versions, this is usually straightforward. For major versions, it often triggers a research phase.
+When work completes, the outcome becomes an ADR; the research that led to it gets deleted. Git remembers the dead ends; the working directory doesn't need to. Old research documents pile up, get re-read, and confuse the AI about what's current versus historical.
 
-**Electron upgrades are special.** Electron major versions regularly break things. The upgrade involves reading the breaking changes list, identifying which ones affect our codebase, spiking workarounds for each, and then implementing them systematically. A single Electron major upgrade can touch dozens of files. Without AI assistance, I'd budget a full weekend for each one.
+## Other Recurring Sessions
 
-**Release judgement stays with me.** The agent can upgrade, test, and prepare a release. But the decision to actually ship — whether to batch more fixes, whether the timing is right, whether users need a heads-up — that's mine.
-
-## Feature Implementation
-
-When a feature gets the green light, the implementation flow follows a consistent pattern:
-
-**Clear specification first.** I describe what the feature should do, how it should behave, and — just as importantly — what it should *not* do. Scope boundaries matter. The AI will happily over-engineer if you let it.
-
-**Incremental implementation.** Large features get broken into small, reviewable chunks. Each chunk gets implemented, tested, and reviewed before moving to the next. This isn't just good practice — it's essential when working with AI, because catching a wrong direction early costs minutes, while catching it late costs hours of throwaway work.
-
-**Tests alongside code.** The agent writes tests as part of implementation, not as an afterthought. The CLAUDE.md file specifies the testing conventions, so the tests follow the project's existing patterns.
-
-**Review everything.** Every piece of AI-generated code gets read. Not skimmed — read. I'm looking for subtle issues: does this respect the module boundaries? Does it handle the Electron edge cases? Does it maintain backwards compatibility where needed? The AI produces good code most of the time, but "most of the time" isn't good enough for a project with thousands of users.
-
-## Keeping the Context Clean
-
-When an implementation is done, I follow a traditional practice: the outcome gets stored as an ADR (Architecture Decision Record). The research document that led to it gets deleted.
-
-This might sound wasteful — why throw away research? — but it's deliberate. The research is always recoverable from git history if I need it. What matters is keeping the current context clean. If old research documents pile up in the repository, the AI reads them and gets confused about what's current versus what's historical. It starts referencing outdated spike results or superseded plans.
-
-The ADR captures the decision and its rationale. That's what future sessions need. The messy path that got there — the dead ends, the discarded spikes, the abandoned approaches — is noise once the decision is made. Git remembers it. The working directory doesn't need to.
-
-## Session Types
-
-Dependency upgrades are the most frequent kind of session, but they aren't the only one. Beyond the loop covered above, a few other recurring session types make up most of the maintenance work:
-
-**Security sessions.** Review npm audit results, evaluate advisories, patch vulnerabilities. These run frequently because the npm ecosystem never stops producing advisories.
-
-**Documentation tidy.** Update README sections, clean up inline comments that have drifted from the code, refresh CLAUDE.md with new invariants discovered since the last pass.
-
-**Metrics and health checks.** Review issue trends, contributor activity, build times, test coverage changes. Understanding the trajectory of the project, not just the current state.
-
-Each session type — including dependency upgrades — follows the same core pattern: I set the scope, the AI executes within it, I review the results. The difference is what we're looking at, not how we work.
-
-Right now these sessions run when I get to them. I'd like to semi-automate the recurring ones — have a monthly report generated that surfaces trends, flags things that need attention, and gives me a snapshot without having to remember to look. The triage bot already does a version of this for issues. Extending that pattern to security posture, dependency freshness, and documentation drift is the natural next step.
+Dependency upgrades are the most frequent kind of session, but not the only one. Security sessions evaluate and patch advisories. Documentation passes update READMEs and refresh CLAUDE.md with newly discovered invariants. Metrics sessions look at issue trends, contributor activity, build times, test coverage. Each follows the same shape: I set the scope, the AI executes, I review.
 
 ## Handling Upstream Changes
 
-The Teams web app changes without notice. Microsoft doesn't publish a changelog for their web client, and defensive coding against those changes is one of the hardest parts of maintaining teams-for-linux.
-
-When something breaks, the workflow is:
-
-**Triage.** User reports come in. The agent helps categorise them: is this a regression in our code, or did Microsoft change something upstream?
-
-**Investigation.** If it's upstream, the agent examines what changed — comparing DOM structures, network requests, or API responses against what we expect. This detective work is tedious and repetitive, exactly the kind of task AI handles well.
-
-**Assessment.** Not all upstream changes can be worked around. Sometimes Microsoft removes or restricts something that we depended on, and no amount of clever coding can restore the functionality. Recognising when a problem is unfixable is a human judgement call.
-
-**Workaround or accept.** If a workaround exists, we implement it. If it doesn't, I communicate that to users honestly. The agent helps draft the response, but the decision and the tone are mine.
+The Teams web app changes without notice, and defensive coding against those changes is one of the hardest parts of this project. When something breaks, the agent helps me categorise — is this our regression or an upstream change? — and then investigates DOM, network, or API differences. Some changes have workarounds; some don't. Recognising when a problem is unfixable is a human call, and the response to users is mine to write.
 
 ## Quality Gates
 
-Nothing ships without passing through a set of quality gates. These aren't aspirational — they're enforced.
+Nothing ships without passing through enforced gates: CI must pass (linting, type checking, full test suite, no exceptions), every AI-assisted commit carries a `Co-authored-by` tag, every diff gets read manually, and release notes are edited to explain the *why* rather than listing files.
 
-**CI must pass.** The GitHub Actions pipeline runs linting, type checking, and the test suite. No exceptions.
+## Treat It As a Team
 
-**Co-authored-by tags on every AI-assisted commit.** This is non-negotiable transparency. If the AI helped write it, the commit says so.
-
-**Manual review of every change.** I read every diff before it gets committed. No exceptions for AI-generated code.
-
-**Release notes that explain the "why."** The agent drafts release notes, but I edit them to make sure they're useful to users — not just a list of file changes, but an explanation of what improved and why it matters.
-
-## What I've Learned
-
-After months of working this way, a few things stand out.
-
-**The workflow is the product.** The specific AI tool matters less than the process around it. Research before implementation. Spikes before commitment. Review before merge. These practices make AI assistance effective; without them, you're just generating code faster without generating better outcomes.
-
-**CLAUDE.md is the highest-leverage investment.** Every hour spent documenting invariants, boundaries, and conventions saves many hours of correcting the AI later. It's the equivalent of onboarding documentation — except the AI actually reads it every time.
-
-**The maintainer's job shifts, but doesn't shrink.** I spend less time writing boilerplate and more time reviewing, deciding, and communicating. The total hours haven't decreased much. What changed is that those hours produce more value.
-
-**Treat it as a team, not a tool.** You almost have to. Once you've built enough harness around the AI — CLAUDE.md, the research-then-spike loop, manual review, CI gates — you're not really using a tool any more, you're directing a system. The pattern is the same one you'd apply to any software that grows: build trust with data, add hardness as you go, simplify or remove what stops earning its place. The difference is that the cycles run faster.
+Once you've built enough harness around the AI — CLAUDE.md, the research-then-spike loop, manual review, CI gates — you're not using a tool any more, you're directing a system. The pattern is the same one you'd apply to any software that grows: build trust with data, add hardness as you go, simplify or remove what stops earning its place. The difference is that the cycles run faster.
 
 ## Closing Thought
 
-This workflow isn't a template. It's what works for a specific project with a specific maintainer. Your version will look different — different tools, different constraints, different priorities.
+This workflow isn't a template — it's what works for a specific project with a specific maintainer. Your version will look different. But the underlying pattern is portable: a human at the start, a human at the end, the tool in between. Drop either bracket and you're either not leveraging AI effectively or not maintaining the quality your users deserve.
 
-But the underlying pattern is portable: a human at the start, a human at the end, the tool in between. Drop either bracket and you're either not leveraging AI effectively or not maintaining the quality your users deserve.
-
-The [principles article](/en/articles/ai-assisted-open-source-maintenance) covers the why. This article covered the how. Together, they're the full picture of what AI-assisted open source maintenance actually looks like in practice.
+The [principles article](/en/articles/ai-assisted-open-source-maintenance) covered the why. This article covered the how. Together they're the full picture.

--- a/src/content/articles/en/ai-assisted-open-source-workflow.mdx
+++ b/src/content/articles/en/ai-assisted-open-source-workflow.mdx
@@ -1,6 +1,6 @@
 ---
 title: "AI-Assisted Open Source: The Workflow"
-description: "The practical workflow behind maintaining teams-for-linux with AI — from CLAUDE.md to research spikes, dependency upgrades, feature implementation, and quality gates."
+description: "The practical workflow behind maintaining teams-for-linux with AI: from CLAUDE.md to research spikes, dependency upgrades, feature implementation, and quality gates."
 publishedDate: 2026-03-11
 tags: ["AI", "Open Source", "Software Development", "Teams for Linux"]
 draft: true
@@ -8,25 +8,25 @@ draft: true
 
 ## From Principles to Practice
 
-The [companion article](/en/articles/ai-assisted-open-source-maintenance) covered what AI changes when maintaining an open-source project. This one is the day-to-day workflow. The core pattern is always the same: I decide, the AI executes, I review. None of this is theoretical — it's what I've settled into after months of iteration, and it keeps evolving.
+The [companion article](/en/articles/ai-assisted-open-source-maintenance) covered what AI changes when maintaining an open-source project. This one is the day-to-day workflow. The core pattern is always the same: I decide, the AI executes, I review. None of this is theoretical. It's what I've settled into after months of iteration, and it keeps evolving.
 
 ## CLAUDE.md as a Living Document
 
-Every interaction starts with CLAUDE.md. The file is short but dense — architectural invariants, module boundaries, build and test commands, commit conventions, and known constraints like Electron quirks or Wayland-specific behaviour. When I discover a new invariant or footgun, it goes in before anything else. The investment pays off on every subsequent interaction.
+Every interaction starts with CLAUDE.md. The file is short but dense: architectural invariants, module boundaries, build and test commands, commit conventions, known constraints like Electron quirks or Wayland-specific behaviour. For example, this project forbids logging anything sensitive like broker URLs, email addresses, or auth tokens. That's exactly the kind of detail an AI will helpfully sprinkle through `console.info` calls unless you tell it not to. When I discover a new invariant or footgun, it goes in before anything else. The investment pays off on every subsequent interaction.
 
 ## Research Before Coding
 
-Most non-trivial changes start with research, not implementation. I describe the problem ("screen sharing breaks on Wayland with the latest Electron update"); the agent investigates the relevant source, changelog, and upstream issues. For anything non-obvious I ask for a spike — a throwaway prototype that tests one specific hypothesis. Once an approach is viable, the agent writes a plan; I review it, flag risks, and only then does implementation begin. Simple bug fixes skip the spike; complex Electron upgrades need several rounds. The process adapts; what doesn't change is that I understand what's happening before committing to an approach.
+Most non-trivial changes start with research, not implementation. I describe the problem ("screen sharing breaks on Wayland with the latest Electron update"); the agent investigates the relevant source, changelog, and upstream issues. For anything non-obvious I ask for a spike: a throwaway prototype that tests one specific hypothesis. Once an approach is viable, the agent writes a plan. I review it, flag risks, and only then does implementation begin. Simple bug fixes skip the spike; complex Electron upgrades need several rounds. The process adapts; what doesn't change is that I understand what's happening before committing to an approach.
 
 ## Dependency Upgrades
 
-This is where AI assistance saves the most time. Dependabot or npm audit flags something; the agent reads the advisory, checks what changed, and judges whether it affects us — many advisories are for code paths we don't use. Minor and patch versions are usually straightforward. Major versions often trigger a research phase. Electron majors are special: they routinely touch dozens of files, and without AI I'd budget a full weekend per upgrade. The release decision — whether to ship now or batch more fixes — stays with me.
+This is where AI assistance saves the most time. Dependabot or npm audit flags something; the agent reads the advisory, checks what changed, and judges whether it affects us. Many advisories are for code paths we don't use. Minor and patch versions are usually straightforward. Major versions often trigger a research phase. Electron majors are special: they routinely touch dozens of files, and without AI I'd budget a full weekend per upgrade. The release decision, whether to ship now or batch more fixes, stays with me.
 
 ## Features and the Context-Clean Habit
 
 When a feature gets the green light, the flow is consistent: clear specification including what *not* to do, incremental implementation in reviewable chunks, tests written alongside (the AI follows the patterns documented in CLAUDE.md), and a full read of every diff. The AI produces good code most of the time, but "most of the time" isn't good enough for thousands of users.
 
-When work completes, the outcome becomes an ADR; the research that led to it gets deleted. Git remembers the dead ends; the working directory doesn't need to. Old research documents pile up, get re-read, and confuse the AI about what's current versus historical.
+When work completes, the outcome becomes an ADR. The research that led to it gets deleted. Git remembers the dead ends; the working directory doesn't need to. Old research documents pile up, get re-read, and confuse the AI about what's current versus historical.
 
 ## Other Recurring Sessions
 
@@ -34,7 +34,7 @@ Dependency upgrades are the most frequent kind of session, but not the only one.
 
 ## Handling Upstream Changes
 
-The Teams web app changes without notice, and defensive coding against those changes is one of the hardest parts of this project. When something breaks, the agent helps me categorise — is this our regression or an upstream change? — and then investigates DOM, network, or API differences. Some changes have workarounds; some don't. Recognising when a problem is unfixable is a human call, and the response to users is mine to write.
+The Teams web app changes without notice, and defensive coding against those changes is one of the hardest parts of this project. When something breaks, the agent helps me categorise. Is this our regression or an upstream change? Then it investigates DOM, network, or API differences. Some changes have workarounds; some don't. Recognising when a problem is unfixable is a human call, and the response to users is mine to write.
 
 ## Quality Gates
 
@@ -42,10 +42,10 @@ Nothing ships without passing through enforced gates: CI must pass (linting, typ
 
 ## Treat It As a Team
 
-Once you've built enough harness around the AI — CLAUDE.md, the research-then-spike loop, manual review, CI gates — you're not using a tool any more, you're directing a system. The pattern is the same one you'd apply to any software that grows: build trust with data, add hardness as you go, simplify or remove what stops earning its place. The difference is that the cycles run faster.
+Once you've built enough harness around the AI (CLAUDE.md, the research-then-spike loop, manual review, CI gates), you're not using a tool any more. You're directing a system. The pattern is the same one you'd apply to any software that grows: build trust with data, add hardness as you go, simplify or remove what stops earning its place. The difference is that the cycles run faster.
 
 ## Closing Thought
 
-This workflow isn't a template — it's what works for a specific project with a specific maintainer. Your version will look different. But the underlying pattern is portable: a human at the start, a human at the end, the tool in between. Drop either bracket and you're either not leveraging AI effectively or not maintaining the quality your users deserve.
+This workflow isn't a template. It's what works for a specific project with a specific maintainer. Your version will look different. But the underlying pattern is portable: a human at the start, a human at the end, the tool in between. Drop either bracket and you're either not leveraging AI effectively or not maintaining the quality your users deserve.
 
 The [principles article](/en/articles/ai-assisted-open-source-maintenance) covered the why. This article covered the how. Together they're the full picture.

--- a/src/content/articles/en/ai-assisted-open-source-workflow.mdx
+++ b/src/content/articles/en/ai-assisted-open-source-workflow.mdx
@@ -116,7 +116,7 @@ Nothing ships without passing through a set of quality gates. These aren't aspir
 
 **Co-authored-by tags on every AI-assisted commit.** This is non-negotiable transparency. If the AI helped write it, the commit says so.
 
-**Manual review of every change.** I read every diff before it gets committed. The AI can propose changes, but I decide what actually goes into the codebase.
+**Manual review of every change.** I read every diff before it gets committed. No exceptions for AI-generated code.
 
 **Release notes that explain the "why."** The agent drafts release notes, but I edit them to make sure they're useful to users — not just a list of file changes, but an explanation of what improved and why it matters.
 
@@ -130,7 +130,7 @@ After months of working this way, a few things stand out.
 
 **The maintainer's job shifts, but doesn't shrink.** I spend less time writing boilerplate and more time reviewing, deciding, and communicating. The total hours haven't decreased much. What changed is that those hours produce more value.
 
-**Working in the open teaches you things.** The co-authored-by tags and the CLAUDE.md file are there for anyone to see. That visibility turns the project into a learning experiment — which AI-assisted changes land well, which ones generate friction, what the community actually cares about. You can't learn any of that if you hide the process.
+**Treat it as a team, not a tool.** You almost have to. Once you've built enough harness around the AI — CLAUDE.md, the research-then-spike loop, manual review, CI gates — you're not really using a tool any more, you're directing a system. The pattern is the same one you'd apply to any software that grows: build trust with data, add hardness as you go, simplify or remove what stops earning its place. The difference is that the cycles run faster.
 
 ## Closing Thought
 

--- a/src/content/articles/en/ai-assisted-open-source-workflow.mdx
+++ b/src/content/articles/en/ai-assisted-open-source-workflow.mdx
@@ -136,6 +136,6 @@ After months of working this way, a few things stand out.
 
 This workflow isn't a template. It's what works for a specific project with a specific maintainer. Your version will look different — different tools, different constraints, different priorities.
 
-But the underlying pattern applies broadly: humans decide, AI executes, humans review. Skip any of those steps and you're either not leveraging AI effectively or not maintaining the quality your users deserve.
+But the underlying pattern is portable: a human at the start, a human at the end, the tool in between. Drop either bracket and you're either not leveraging AI effectively or not maintaining the quality your users deserve.
 
 The [principles article](/en/articles/ai-assisted-open-source-maintenance) covers the why. This article covered the how. Together, they're the full picture of what AI-assisted open source maintenance actually looks like in practice.

--- a/src/content/articles/en/ai-assisted-open-source-workflow.mdx
+++ b/src/content/articles/en/ai-assisted-open-source-workflow.mdx
@@ -82,7 +82,7 @@ The ADR captures the decision and its rationale. That's what future sessions nee
 
 ## Session Types
 
-The research-to-implementation workflow isn't the only kind of session I run. Maintenance involves several recurring session types, each with its own focus:
+Dependency upgrades are the most frequent kind of session, but they aren't the only one. Beyond the loop covered above, a few other recurring session types make up most of the maintenance work:
 
 **Security sessions.** Review npm audit results, evaluate advisories, patch vulnerabilities. These run frequently because the npm ecosystem never stops producing advisories.
 
@@ -90,9 +90,7 @@ The research-to-implementation workflow isn't the only kind of session I run. Ma
 
 **Metrics and health checks.** Review issue trends, contributor activity, build times, test coverage changes. Understanding the trajectory of the project, not just the current state.
 
-**Dependency upgrades.** The loop described above — detection, assessment, upgrade, test, release decision.
-
-Each session type follows the same core pattern: I set the scope, the AI executes within it, I review the results. The difference is what we're looking at, not how we work.
+Each session type — including dependency upgrades — follows the same core pattern: I set the scope, the AI executes within it, I review the results. The difference is what we're looking at, not how we work.
 
 Right now these sessions run when I get to them. I'd like to semi-automate the recurring ones — have a monthly report generated that surfaces trends, flags things that need attention, and gives me a snapshot without having to remember to look. The triage bot already does a version of this for issues. Extending that pattern to security posture, dependency freshness, and documentation drift is the natural next step.
 

--- a/src/content/articles/es/ai-assisted-open-source-cadences.mdx
+++ b/src/content/articles/es/ai-assisted-open-source-cadences.mdx
@@ -1,0 +1,37 @@
+---
+title: "Código abierto asistido por IA: cadencias y señales"
+description: "Qué cambia cuando ejecutas varios proyectos a distintas velocidades: vida larga, estacional, efímero, reactivo. La disciplina es la misma; las restricciones tienen que doblarse con el ciclo de vida, y las señales se convierten en la verdadera limitación."
+publishedDate: 2026-03-18
+tags: ["IA", "Código Abierto", "Desarrollo de Software", "Teams for Linux"]
+draft: true
+---
+
+## De un proyecto a varios
+
+El [primer artículo](/es/articles/ai-assisted-open-source-maintenance) preguntó qué cambia la IA al mantener un proyecto open source, a través del lente de un código de 7 años. El [segundo](/es/articles/ai-assisted-open-source-workflow) fue el flujo de trabajo que lo mantiene en marcha. Ambos se quedaron dentro de una sola cadencia de vida larga. Este sale de ese marco: la asistencia de IA hace que ejecutar varios proyectos en paralelo, a distintas velocidades, sea realmente factible, y eso cambia lo que el flujo de trabajo tiene que manejar.
+
+## Cuatro cadencias
+
+teams-for-linux es el de vida larga: siete años de historia, cientos de miles de usuarios activos, todas las restricciones.
+
+bonnie-wee-plot es estacional, una app escocesa de huerto donde las funcionalidades que importan en marzo (ventanas de siembra) son distintas de las que importan en agosto (cosecha, vigilancia de tizón). El código crece en capítulos, con el año hortícola diciéndole qué construir a continuación.
+
+votescot es efímero, una brújula de voto open source construida para las elecciones del Parlamento Escocés de 2026. La ventana de relevancia es estrecha; el código tiene que ser sólido durante toda su duración, pero el ciclo de vida tiene un final incorporado.
+
+wifisentinel es reactivo, construido rápidamente porque una situación específica lo necesitaba (un Airbnb sospechoso en Ámsterdam donde quería saber qué había realmente en la red). Lo que empezó como una herramienta puntual creció hasta convertirse en un kit completo una vez que el problema original se resolvió.
+
+## Ajusta las restricciones a la cadencia
+
+Las restricciones completas del Artículo 2 son adecuadas para un proyecto de 7 años y equivocadas para una brújula de voto de un mes. Proceso máximo en un código efímero es sobrecarga disfrazada de rigor. Pero "menos restricciones" no es "ninguna restricción": votescot sigue teniendo CI, linting y revisión manual en cada diff. Los estándares que protegen a los usuarios de un comportamiento roto se aplican en cada cadencia; los que protegen un código de vida larga contra la confusión del yo futuro no se aplican cuando no hay yo futuro al que confundir. La disciplina es ajustar las restricciones al ciclo de vida, no aplicar ceremonia máxima en todas partes.
+
+## La Estrella de la Muerte sigue siendo real
+
+Los bugs se esconden en la complejidad. La IA no deroga esa regla; la hace más urgente. Cuando el coste de escribir código baja, solo baja el coste de escribir, no el de leer, el de depurar ni el de retirar. La tentación de seguir añadiendo es mayor que nunca, lo que significa que decir "no, eso es una Estrella de la Muerte" importa más, no menos. En cada cadencia se manifiesta de forma distinta. "Diez años de mantenimiento" en un proyecto de vida larga, "demasiado astuto para seis semanas" en uno efímero. Pero es el mismo recordatorio.
+
+## Las señales son la limitación
+
+Con asistencia de IA y restricciones del tamaño adecuado, el cuello de botella se desplaza. Ya no es cuánto código puedes lanzar; eso está resuelto. Es si puedes detectar, a tiempo, cuándo algo ha ido mal. Los tests son señal. CI es señal. La revisión manual es señal. Los ADRs son señal sobre decisiones. Las restricciones existen para producir señal; el flujo de trabajo existe para actuar sobre ella. El viaje es el mismo que cualquier mantenedor ha conocido siempre: construir confianza con datos, añadir solidez a medida que avanzas, simplificar o quitar lo que deja de ganarse su sitio. La IA acelera los ciclos, así que la calidad de la señal tiene que seguirles el ritmo. Escatimar en eso es lo que convierte la productividad asistida por IA en un caos amplificado por IA.
+
+## Reflexión final
+
+Misma disciplina, ciclos de vida muy diferentes. Las restricciones se doblan, la cadencia dicta la forma, y las señales se convierten en aquello que optimizas. El viaje no está terminado. La taxonomía de cadencias necesitará nuevas categorías, y la Estrella de la Muerte seguirá siendo una tentación. Lo que cambia es lo rápido que puedes moverte por los ciclos, y si tu calidad de señal sigue el ritmo de tu velocidad.

--- a/src/content/articles/es/ai-assisted-open-source-maintenance.mdx
+++ b/src/content/articles/es/ai-assisted-open-source-maintenance.mdx
@@ -3,7 +3,7 @@ title: "Código abierto asistido por IA: qué cambia y qué no"
 description: "Cómo las herramientas de IA encajan en el mantenimiento de un proyecto open source de 7 años — qué acelera, qué no puede reemplazar y por qué existe el archivo CLAUDE.md."
 publishedDate: 2026-03-03
 tags: ["IA", "Código Abierto", "Desarrollo de Software", "Teams for Linux"]
-draft: true
+draft: false
 ---
 
 ## El proyecto es anterior a las herramientas
@@ -19,6 +19,8 @@ Cuando la gente vio el archivo CLAUDE.md en el repositorio, algunos asumieron qu
 CLAUDE.md es un archivo de configuración, parecido a `.editorconfig` o `tsconfig.json`. Le dice a la herramienta de IA cómo comportarse en este código específico. Documenta decisiones arquitectónicas, límites de módulos e invariantes críticos — como el requisito de inicialización de `trayIconRenderer`/`mqttStatusMonitor` que se ha roto accidentalmente varias veces por contribuidores que no conocían la dependencia.
 
 El archivo codifica conocimiento específico del proyecto para que la herramienta de IA respete los patrones existentes en lugar de inventar nuevos. Cada código tiene reglas no escritas. CLAUDE.md las hace explícitas. No es una señal de autoría por IA. Es una señal de disciplina con la IA.
+
+En el [artículo complementario sobre el flujo de trabajo real](/es/articles/ai-assisted-open-source-workflow) profundizo en cómo este archivo da forma a cada interacción — desde investigaciones hasta actualizaciones de dependencias e implementación de funcionalidades.
 
 ## Qué acelera realmente la IA
 
@@ -45,6 +47,8 @@ Las decisiones arquitectónicas están en la misma categoría. Cuándo refactori
 El criterio de lanzamiento es más matizado de lo que parece. ¿Está lista esta build? ¿Debería acumular más correcciones primero? ¿Es la corrección de Wayland lo suficientemente estable para publicar, o necesita otra semana de pruebas? Estas decisiones requieren contexto al que ninguna herramienta tiene acceso.
 
 Entender los cambios upstream es un desafío constante. La webapp de Teams cambia sin aviso, y la programación defensiva contra esos cambios requiere un conocimiento profundo del dominio sobre lo que Microsoft probablemente hará y cómo evoluciona su plataforma. La IA no sabe qué publicó Microsoft el martes pasado.
+
+Algunos problemas simplemente no tienen solución, independientemente de las herramientas. Cuando Microsoft cambia su webapp de formas que rompen clientes de terceros, ninguna cantidad de programación asistida por IA puede producir una solución alternativa que no existe. El mantenedor tiene que reconocer cuándo un problema no tiene buena solución, comunicarlo honestamente a los usuarios y seguir adelante. La IA seguirá intentando generar correcciones para cosas que no se pueden corregir.
 
 Y luego está decir no a las peticiones de funcionalidades. Eso es quizás la parte más difícil de mantener un proyecto popular, y es enteramente una habilidad humana.
 
@@ -75,3 +79,5 @@ La pregunta interesante no es "¿escribió la IA este código?"
 Es si el proyecto funciona, si se mantiene y si los usuarios están bien atendidos. Por esas medidas, las herramientas de IA están haciendo exactamente lo que deberían — mantener vivo y receptivo un proyecto útil cuando la alternativa es la decadencia lenta.
 
 En [La trampa de la automatización con IA](/es/articles/the-ai-automation-trap) escribí sobre cómo la IA eliminó la restricción de construir pero no eliminó la restricción de decidir. Este proyecto es el ejemplo vivido. La IA se encarga de construir. El decidir, el mantener y el preocuparse por los usuarios — eso sigue siendo completamente humano. Y siempre lo será.
+
+Si quieres ver cómo funciona esto en el día a día — el flujo de trabajo específico, las herramientas, los controles de calidad — lee [Código abierto asistido por IA: el flujo de trabajo](/es/articles/ai-assisted-open-source-workflow).

--- a/src/content/articles/es/ai-assisted-open-source-maintenance.mdx
+++ b/src/content/articles/es/ai-assisted-open-source-maintenance.mdx
@@ -62,15 +62,13 @@ Con herramientas de IA, puedo mantener el ritmo con parches de seguridad, actual
 
 La alternativa al mantenimiento asistido por IA no es "escribirlo todo a mano." Es "dejar que los issues se acumulen y eventualmente abandonar el proyecto." Para mantenedores de código abierto en solitario, la IA es una herramienta de sostenibilidad, no un atajo.
 
-## Los marcadores visibles
+## Trabajar a la vista
 
-Cada commit asistido por IA en el repositorio lleva una etiqueta `Co-authored-by`. Eso es transparencia, no confesión.
+Cada commit asistido por IA en el repositorio lleva una etiqueta `Co-authored-by`. El archivo CLAUDE.md está incluido en el repositorio donde cualquiera puede leerlo. Esto no es hacer una declaración — es aprender.
 
-El archivo CLAUDE.md está incluido en el repositorio donde cualquiera puede leerlo. Podría ocultar todo esto fácilmente. Quitar las etiquetas de coautoría, eliminar el archivo de configuración, y nadie lo sabría. Elegí no hacerlo porque ser abierto sobre las herramientas es lo correcto.
+Quiero entender qué funciona. ¿Qué tipos de cambios asistidos por IA son aceptados sin problemas por la comunidad? ¿Cuáles generan fricción? ¿Cambia la participación visible de la IA cómo la gente interactúa con el proyecto? Son preguntas abiertas, y la única forma de responderlas es ser abierto sobre el proceso.
 
-La ironía es que ocultar el uso de IA es trivialmente fácil y casi seguro que está generalizado. Los proyectos que son transparentes al respecto son los que reciben escrutinio, mientras que los proyectos que lo ocultan no enfrentan ninguna pregunta. Esa estructura de incentivos está al revés.
-
-La transparencia sobre el uso de IA debería normalizarse, no penalizarse. La conversación debería ser sobre resultados — ¿funciona el software, se mantiene, se atiende bien a los usuarios? — no sobre qué herramientas usó el mantenedor para llegar ahí.
+Si otros mantenedores eligen mostrar u ocultar su uso de IA es asunto suyo. No me interesa ese debate. Lo que me interesa es hacer un experimento honesto: mantener un proyecto abiertamente con herramientas de IA, ver cuál es realmente la respuesta de la comunidad, y compartir lo que aprenda.
 
 ## Reflexión final
 

--- a/src/content/articles/es/ai-assisted-open-source-maintenance.mdx
+++ b/src/content/articles/es/ai-assisted-open-source-maintenance.mdx
@@ -3,7 +3,7 @@ title: "Código abierto asistido por IA: qué cambia y qué no"
 description: "Cómo las herramientas de IA encajan en el mantenimiento de un proyecto open source de 7 años — qué acelera, qué no puede reemplazar y por qué existe el archivo CLAUDE.md."
 publishedDate: 2026-03-03
 tags: ["IA", "Código Abierto", "Desarrollo de Software", "Teams for Linux"]
-draft: false
+draft: true
 ---
 
 ## El proyecto es anterior a las herramientas

--- a/src/content/articles/es/ai-assisted-open-source-maintenance.mdx
+++ b/src/content/articles/es/ai-assisted-open-source-maintenance.mdx
@@ -8,7 +8,7 @@ draft: true
 
 ## El proyecto es anterior a las herramientas
 
-teams-for-linux empezó en 2018. Eso es más de cinco años antes de que existiera cualquier herramienta de programación con IA. Construí un wrapper Electron para Microsoft Teams porque Microsoft dejó de dar soporte oficial a Linux y miles de desarrolladores necesitaban un cliente que funcionara. El proyecto creció orgánicamente hasta superar las 4.400 estrellas, 315 forks y 30 contribuidores a lo largo de los años.
+teams-for-linux empezó en 2018, años antes de que las herramientas de programación con IA se generalizaran. Construí un wrapper Electron para Microsoft Teams porque no existía un cliente oficial para Linux en ese momento — Microsoft no lanzaría uno hasta finales de 2019, y cuando finalmente lo retiraron en 2023, teams-for-linux se convirtió en la opción de facto. El proyecto creció orgánicamente hasta superar las 4.500 estrellas, 320 forks y decenas de contribuidores a lo largo de los años.
 
 La adopción de IA llegó mucho después. Es una elección de herramientas que hice para mantener el ritmo con las demandas de mantener un proyecto de este tamaño, no la historia de origen. La cronología importa porque a veces la gente mira un repositorio, ve señales de herramientas de IA y asume que todo fue generado. No fue así. El proyecto tiene siete años de historia, comunidad y decisiones arquitectónicas ganadas con esfuerzo detrás.
 

--- a/src/content/articles/es/ai-assisted-open-source-maintenance.mdx
+++ b/src/content/articles/es/ai-assisted-open-source-maintenance.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Código abierto asistido por IA: qué cambia y qué no"
-description: "Cómo las herramientas de IA encajan en el mantenimiento de un proyecto open source de 7 años — qué acelera, qué no puede reemplazar y por qué existe el archivo CLAUDE.md."
+description: "Cómo las herramientas de IA encajan en el mantenimiento de un proyecto open source de 7 años: qué acelera, qué no puede reemplazar y por qué existe el archivo CLAUDE.md."
 publishedDate: 2026-03-03
 tags: ["IA", "Código Abierto", "Desarrollo de Software", "Teams for Linux"]
 draft: true
@@ -8,74 +8,30 @@ draft: true
 
 ## El proyecto es anterior a las herramientas
 
-teams-for-linux empezó en 2018, años antes de que las herramientas de programación con IA se generalizaran. Construí un wrapper Electron para Microsoft Teams porque no existía un cliente oficial para Linux en ese momento — Microsoft no lanzaría uno hasta finales de 2019, y cuando finalmente lo retiraron a finales de 2022, teams-for-linux se convirtió en la opción de facto. El proyecto ha crecido orgánicamente hasta superar las 4.600 estrellas, 330 forks y decenas de contribuidores a lo largo de los años (cifras en el momento de escribir).
+Cuando teams-for-linux empezó en 2018, las herramientas de programación con IA no estaban en la cabeza de nadie. Escribíamos el código, escribíamos los tests, revisábamos la cobertura. Lo de siempre. El proyecto nació por necesidad: Microsoft no tenía cliente para Linux, y su web app no entregaba notificaciones, lo que la hacía bastante inútil como app de chat.
 
-La adopción de IA llegó mucho después. Es una elección de herramientas que hice para mantener el ritmo con las demandas de mantener un proyecto de este tamaño, no la historia de origen. La cronología importa porque a veces la gente mira un repositorio, ve señales de herramientas de IA y asume que todo fue generado. No fue así. El proyecto tiene siete años de historia, comunidad y decisiones arquitectónicas ganadas con esfuerzo detrás.
+A finales de 2019 Microsoft finalmente lanzó una preview oficial para Linux, así que el proyecto pasó a segundo plano y aproveché para oler las rosas. Eso duró hasta finales de 2022, cuando Microsoft retiró el cliente y mucha gente volvió aquí. Ahora es 2026 y, en el momento de escribir, el repositorio tiene más de 4.000 estrellas y 300 forks.
 
-## Qué es realmente CLAUDE.md
+Para un mantenedor en solitario en un proyecto de este tamaño, la programación asistida por IA no es realmente una cuestión de *si*. Es una cuestión de *cómo hacerlo bien*. Este artículo expone los principios; el resto de la serie es donde lo trabajo en la práctica.
 
-Cuando la gente vio el archivo CLAUDE.md en el repositorio, algunos asumieron que significaba que el proyecto estaba escrito por IA. Eso es un malentendido de lo que hace el archivo.
+## Qué acelera la IA y qué no
 
-CLAUDE.md es un archivo de configuración, parecido a `.editorconfig` o `tsconfig.json`. Le dice a la herramienta de IA cómo comportarse en este código específico. Documenta decisiones arquitectónicas, límites de módulos e invariantes críticos — como el requisito de inicialización de `trayIconRenderer`/`mqttStatusMonitor` que se ha roto accidentalmente varias veces por contribuidores que no conocían la dependencia.
+La IA se encarga del trabajo que de otro modo quemaría a un mantenedor en solitario: implementación de funcionalidades bien definidas, actualizaciones de dependencias y parches de seguridad (que el ecosistema npm produce varias veces por semana), explorar APIs poco familiares y triar issues a escala. La forma exacta sigue evolucionando. Sigo experimentando con qué delegar y cómo, con herramientas como [repo-butler](https://github.com/IsmaelMartinez/repo-butler) vigilando la salud del portafolio junto al propio proyecto. El objetivo no es solo ahorrarme tiempo; es también ahorrar tiempo a quienes reportan, y mejorar la herramienta para todos.
 
-El archivo codifica conocimiento específico del proyecto para que la herramienta de IA respete los patrones existentes en lugar de inventar nuevos. Cada código tiene reglas no escritas. CLAUDE.md las hace explícitas. No es una señal de autoría por IA. Es una señal de disciplina con la IA.
-
-En el [artículo complementario sobre el flujo de trabajo real](/es/articles/ai-assisted-open-source-workflow) profundizo en cómo este archivo da forma a cada interacción — desde investigaciones hasta actualizaciones de dependencias e implementación de funcionalidades.
-
-## Qué acelera realmente la IA
-
-Las tareas que la IA maneja bien son las que de otro modo agotarían a un mantenedor en solitario.
-
-La implementación de funcionalidades bien entendidas es lo más obvio. Una vez que he decidido qué construir y cómo debería funcionar, la programación en sí — la traducción mecánica de intención a código — va más rápido con asistencia de IA. El boilerplate, el scaffolding de tests y las actualizaciones de documentación caen en la misma categoría. Son trabajo necesario, pero no requieren criterio creativo.
-
-Las actualizaciones de dependencias y las respuestas a parches de seguridad son donde el ahorro de tiempo realmente se acumula. El ecosistema npm envía avisos de seguridad varias veces por semana. Cada uno necesita evaluación, parcheo, pruebas y lanzamiento. Sin herramientas, eso solo puede consumir la mayoría de las horas disponibles de un mantenedor.
-
-Explorar APIs poco familiares es otra área donde la IA destaca. La superficie de API de Electron es enorme, Wayland tiene sus propias peculiaridades, y Linux es una caja llena de sorpresas. Tener una herramienta que puede mostrar rápidamente documentación relevante y patrones de uso reduce significativamente el tiempo de exploración.
-
-También construí un bot de triaje con Gemini para issues de GitHub. Cuando un proyecto recibe cientos de issues, separar la señal del ruido manualmente no es sostenible. El bot se encarga de la categorización inicial para que yo pueda centrarme en los issues que realmente necesitan atención humana.
-
-## Qué no puede reemplazar la IA
-
-El trabajo difícil de mantener un proyecto de código abierto no es escribir código. Nunca lo fue.
-
-Decidir qué construir y qué no construir requiere entender la dirección del proyecto, las necesidades de la comunidad y las compensaciones de cada adición. La IA no tiene opinión sobre esto. Construirá felizmente lo que le pidas, necesite el proyecto o no.
-
-La gestión de la comunidad es trabajo completamente humano. Cuando los usuarios empezaron a quejarse de la frecuencia de actualizaciones — la conversación de "calma con las actualizaciones" — eso requería empatía, leer el ambiente y hacer un juicio sobre la cadencia de lanzamientos. Ninguna herramienta de IA puede navegar eso.
-
-Las decisiones arquitectónicas están en la misma categoría. Cuándo refactorizar versus cuándo parchear. Dónde trazar los límites de los módulos. Cuánta compatibilidad hacia atrás mantener y cuándo romperla. Estas decisiones dan forma al proyecto durante años y no se pueden delegar a una herramienta que optimiza para la tarea inmediata.
-
-El criterio de lanzamiento es más matizado de lo que parece. ¿Está lista esta build? ¿Debería acumular más correcciones primero? ¿Es la corrección de Wayland lo suficientemente estable para publicar, o necesita otra semana de pruebas? Estas decisiones requieren contexto al que ninguna herramienta tiene acceso.
-
-Entender los cambios upstream es un desafío constante. La webapp de Teams cambia sin aviso, y la programación defensiva contra esos cambios requiere un conocimiento profundo del dominio sobre lo que Microsoft probablemente hará y cómo evoluciona su plataforma. La IA no sabe qué publicó Microsoft el martes pasado.
-
-Algunos problemas simplemente no tienen solución, independientemente de las herramientas. Cuando Microsoft cambia su webapp de formas que rompen clientes de terceros, ninguna cantidad de programación asistida por IA puede producir una solución alternativa que no existe. El mantenedor tiene que reconocer cuándo un problema no tiene buena solución, comunicarlo honestamente a los usuarios y seguir adelante. La IA seguirá intentando generar correcciones para cosas que no se pueden corregir.
-
-Y luego está decir no a las peticiones de funcionalidades. Eso es quizás la parte más difícil de mantener un proyecto popular, y es enteramente una habilidad humana.
+Lo que la IA no puede tocar, al menos por ahora, es la parte que va por el gusto. Decidir qué construir (y qué rechazar), priorizar dentro de la comunidad, entender dónde deberían estar las fronteras, juzgar cuándo una versión está lista, saber cuándo un cambio upstream no tiene solución. Son decisiones humanas. La IA generará encantada arreglos para problemas que no tienen arreglo, y te dirá que tiene razón con la misma convicción tanto si la tiene como si no. Navegar eso, y comunicarse honestamente con los usuarios, es donde vive el trabajo humano.
 
 ## La realidad del mantenedor en solitario
 
-teams-for-linux es un proyecto de un solo mantenedor con miles de usuarios activos. Esa proporción es el desafío fundamental.
+teams-for-linux tiene muchos contribuidores, pero en cualquier momento dado solo ha habido un mantenedor. El testigo ha cambiado de manos un par de veces, sobre todo cuando Microsoft lanzó su propio cliente para Linux y el proyecto entró en modo mantenimiento durante un tiempo. Hoy lo llevo yo, junto a cientos de miles de usuarios activos.
 
-Sin herramientas de IA, las matemáticas no cuadran. Responder a los issues lleva más tiempo. Los lanzamientos ocurren con menos frecuencia. Los parches de seguridad se quedan en la cola. Eventualmente el backlog crece más rápido de lo que una persona puede abordar, y el proyecto se abandona. Eso no es hipotético — es el resultado por defecto para proyectos populares de un solo mantenedor.
+Esa proporción es el reto principal. Incluso con herramientas de IA, mantenerse al día con issues, PRs, lanzamientos y parches de seguridad es una tarea diaria. Y eso encima de tener un trabajo y una vida. Sin IA las cuentas no salen en absoluto: el backlog crece más rápido de lo que una persona puede atender, los lanzamientos se ralentizan, y el proyecto acaba abandonado. Ese es el resultado por defecto para los proyectos populares con un único mantenedor.
 
-Con herramientas de IA, puedo mantener el ritmo con parches de seguridad, actualizaciones de Electron, reportes de usuarios y seguir sacando funcionalidades nuevas. La herramienta se encarga del trabajo mecánico para que pueda dedicar mi tiempo limitado a las decisiones e interacciones con la comunidad que realmente requieren un humano.
-
-La alternativa al mantenimiento asistido por IA no es "escribirlo todo a mano." Es "dejar que los issues se acumulen y eventualmente abandonar el proyecto." Para mantenedores de código abierto en solitario, la IA es una herramienta de sostenibilidad, no un atajo.
+Para los mantenedores en solitario, la IA no es un atajo. Es la diferencia entre seguir adelante y marcharte.
 
 ## Trabajar a la vista
 
-Cada commit asistido por IA en el repositorio lleva una etiqueta `Co-authored-by`. El archivo CLAUDE.md está incluido en el repositorio donde cualquiera puede leerlo. Esto no es hacer una declaración — es aprender.
+Cada commit asistido por IA lleva una etiqueta `Co-authored-by`. La configuración que dirige el comportamiento de la IA en este código, CLAUDE.md, está en el repositorio para que cualquiera lo lea. Podría perfectamente ocultarlo. Guardar los prompts en carpetas personales, dejar las etiquetas fuera, no mencionar nunca qué partes escribió la IA. ¿Pero por qué? La asistencia de IA ya no es una cuestión de *si*, es una cuestión de *cómo*. Es una herramienta, y tratarla como tal significa ser abierto sobre cómo se usa.
 
-Quiero entender qué funciona. ¿Qué tipos de cambios asistidos por IA son aceptados sin problemas por la comunidad? ¿Cuáles generan fricción? ¿Cambia la participación visible de la IA cómo la gente interactúa con el proyecto? Son preguntas abiertas, y la única forma de responderlas es ser abierto sobre el proceso.
+Lo interesante es lo que cambia cuando un proyecto open source maduro adopta estas herramientas. Qué se vuelve posible, cuánto trabajo más puede llevar un mantenedor en solitario, qué se vuelve más fácil y qué sigue siendo difícil. El siguiente artículo de la serie, [El flujo de trabajo](/es/articles/ai-assisted-open-source-workflow), es la forma práctica del día a día.
 
-Si otros mantenedores eligen mostrar u ocultar su uso de IA es asunto suyo. No me interesa ese debate. Lo que me interesa es hacer un experimento honesto: mantener un proyecto abiertamente con herramientas de IA, ver cuál es realmente la respuesta de la comunidad, y compartir lo que aprenda.
-
-## Reflexión final
-
-La pregunta interesante no es "¿escribió la IA este código?"
-
-Es si el proyecto funciona, si se mantiene y si los usuarios están bien atendidos. Por esas medidas, las herramientas de IA están haciendo exactamente lo que deberían — mantener vivo y receptivo un proyecto útil cuando la alternativa es la decadencia lenta.
-
-En [La trampa de la automatización con IA](/es/articles/the-ai-automation-trap) escribí sobre cómo la IA eliminó la restricción de construir pero no eliminó la restricción de decidir. Este proyecto es el ejemplo vivo. La IA se encarga de construir. El decidir, el mantener y el preocuparse por los usuarios — eso sigue siendo completamente humano. Y siempre lo será.
-
-Si quieres ver cómo funciona esto en el día a día — el flujo de trabajo específico, las herramientas, los controles de calidad — lee [Código abierto asistido por IA: el flujo de trabajo](/es/articles/ai-assisted-open-source-workflow).
+Y hay una trampa esperando. En [La trampa de la automatización con IA](/es/articles/the-ai-automation-trap) escribí que la IA eliminó la restricción de construir pero no la de decidir. Cuanto más delegamos en la máquina, más complejidad podemos generar. Y eso significa más que mantener, más que depurar, más que leer. La IA no te saca de ese bucle, ni de ninguno otro. Pasadas de documentación, trabajo de re-arquitectura, inversiones en observabilidad, la larga cola de soporte. Nada de eso desaparece. Simplemente pasa más rápido.

--- a/src/content/articles/es/ai-assisted-open-source-maintenance.mdx
+++ b/src/content/articles/es/ai-assisted-open-source-maintenance.mdx
@@ -32,7 +32,7 @@ Las actualizaciones de dependencias y las respuestas a parches de seguridad son 
 
 Explorar APIs poco familiares es otra área donde la IA destaca. La superficie de API de Electron es enorme, Wayland tiene sus propias peculiaridades, y Trusted Types introdujo un conjunto completamente nuevo de restricciones. Tener una herramienta que puede mostrar rápidamente documentación relevante y patrones de uso reduce significativamente el tiempo de exploración.
 
-También construí un bot de triaje con Gemini para issues de GitHub. Cuando un proyecto recibe cientos de issues, clasificar la señal del ruido manualmente no es sostenible. El bot se encarga de la categorización inicial para que yo pueda centrarme en los issues que realmente necesitan atención humana.
+También construí un bot de triaje con Gemini para issues de GitHub. Cuando un proyecto recibe cientos de issues, separar la señal del ruido manualmente no es sostenible. El bot se encarga de la categorización inicial para que yo pueda centrarme en los issues que realmente necesitan atención humana.
 
 ## Qué no puede reemplazar la IA
 
@@ -76,6 +76,6 @@ La pregunta interesante no es "¿escribió la IA este código?"
 
 Es si el proyecto funciona, si se mantiene y si los usuarios están bien atendidos. Por esas medidas, las herramientas de IA están haciendo exactamente lo que deberían — mantener vivo y receptivo un proyecto útil cuando la alternativa es la decadencia lenta.
 
-En [La trampa de la automatización con IA](/es/articles/the-ai-automation-trap) escribí sobre cómo la IA eliminó la restricción de construir pero no eliminó la restricción de decidir. Este proyecto es el ejemplo vivido. La IA se encarga de construir. El decidir, el mantener y el preocuparse por los usuarios — eso sigue siendo completamente humano. Y siempre lo será.
+En [La trampa de la automatización con IA](/es/articles/the-ai-automation-trap) escribí sobre cómo la IA eliminó la restricción de construir pero no eliminó la restricción de decidir. Este proyecto es el ejemplo vivo. La IA se encarga de construir. El decidir, el mantener y el preocuparse por los usuarios — eso sigue siendo completamente humano. Y siempre lo será.
 
 Si quieres ver cómo funciona esto en el día a día — el flujo de trabajo específico, las herramientas, los controles de calidad — lee [Código abierto asistido por IA: el flujo de trabajo](/es/articles/ai-assisted-open-source-workflow).

--- a/src/content/articles/es/ai-assisted-open-source-maintenance.mdx
+++ b/src/content/articles/es/ai-assisted-open-source-maintenance.mdx
@@ -30,7 +30,7 @@ La implementación de funcionalidades bien entendidas es lo más obvio. Una vez 
 
 Las actualizaciones de dependencias y las respuestas a parches de seguridad son donde el ahorro de tiempo realmente se acumula. El ecosistema npm envía avisos de seguridad varias veces por semana. Cada uno necesita evaluación, parcheo, pruebas y lanzamiento. Sin herramientas, eso solo puede consumir la mayoría de las horas disponibles de un mantenedor.
 
-Explorar APIs poco familiares es otra área donde la IA destaca. La superficie de API de Electron es enorme, Wayland tiene sus propias peculiaridades, y Trusted Types introdujo un conjunto completamente nuevo de restricciones. Tener una herramienta que puede mostrar rápidamente documentación relevante y patrones de uso reduce significativamente el tiempo de exploración.
+Explorar APIs poco familiares es otra área donde la IA destaca. La superficie de API de Electron es enorme, Wayland tiene sus propias peculiaridades, y Linux es una caja llena de sorpresas. Tener una herramienta que puede mostrar rápidamente documentación relevante y patrones de uso reduce significativamente el tiempo de exploración.
 
 También construí un bot de triaje con Gemini para issues de GitHub. Cuando un proyecto recibe cientos de issues, separar la señal del ruido manualmente no es sostenible. El bot se encarga de la categorización inicial para que yo pueda centrarme en los issues que realmente necesitan atención humana.
 

--- a/src/content/articles/es/ai-assisted-open-source-maintenance.mdx
+++ b/src/content/articles/es/ai-assisted-open-source-maintenance.mdx
@@ -8,7 +8,7 @@ draft: true
 
 ## El proyecto es anterior a las herramientas
 
-teams-for-linux empezó en 2018, años antes de que las herramientas de programación con IA se generalizaran. Construí un wrapper Electron para Microsoft Teams porque no existía un cliente oficial para Linux en ese momento — Microsoft no lanzaría uno hasta finales de 2019, y cuando finalmente lo retiraron en 2023, teams-for-linux se convirtió en la opción de facto. El proyecto creció orgánicamente hasta superar las 4.500 estrellas, 320 forks y decenas de contribuidores a lo largo de los años.
+teams-for-linux empezó en 2018, años antes de que las herramientas de programación con IA se generalizaran. Construí un wrapper Electron para Microsoft Teams porque no existía un cliente oficial para Linux en ese momento — Microsoft no lanzaría uno hasta finales de 2019, y cuando finalmente lo retiraron a finales de 2022, teams-for-linux se convirtió en la opción de facto. El proyecto ha crecido orgánicamente hasta superar las 4.600 estrellas, 330 forks y decenas de contribuidores a lo largo de los años (cifras en el momento de escribir).
 
 La adopción de IA llegó mucho después. Es una elección de herramientas que hice para mantener el ritmo con las demandas de mantener un proyecto de este tamaño, no la historia de origen. La cronología importa porque a veces la gente mira un repositorio, ve señales de herramientas de IA y asume que todo fue generado. No fue así. El proyecto tiene siete años de historia, comunidad y decisiones arquitectónicas ganadas con esfuerzo detrás.
 

--- a/src/content/articles/es/ai-assisted-open-source-workflow.mdx
+++ b/src/content/articles/es/ai-assisted-open-source-workflow.mdx
@@ -132,7 +132,7 @@ Después de meses trabajando así, algunas cosas destacan.
 
 **El trabajo del mantenedor cambia, pero no se reduce.** Paso menos tiempo escribiendo boilerplate y más tiempo revisando, decidiendo y comunicando. Las horas totales no han disminuido mucho. Lo que cambió es que esas horas producen más valor.
 
-**La transparencia no cuesta nada.** Ser abierto sobre el uso de IA no ha perjudicado al proyecto. Las etiquetas Co-authored-by y el archivo CLAUDE.md están ahí para que cualquiera los vea. Los usuarios que se preocupan por los resultados — ¿funciona la app, se mantiene, se atienden los issues? — juzgan el proyecto por esos méritos, no por las herramientas usadas.
+**Trabajar a la vista te enseña cosas.** Las etiquetas Co-authored-by y el archivo CLAUDE.md están ahí para que cualquiera los vea. Esa visibilidad convierte el proyecto en un experimento de aprendizaje — qué cambios asistidos por IA funcionan bien, cuáles generan fricción, qué le importa realmente a la comunidad. No puedes aprender nada de eso si ocultas el proceso.
 
 ## Reflexión final
 

--- a/src/content/articles/es/ai-assisted-open-source-workflow.mdx
+++ b/src/content/articles/es/ai-assisted-open-source-workflow.mdx
@@ -1,0 +1,117 @@
+---
+title: "Código abierto asistido por IA: el flujo de trabajo"
+description: "El flujo de trabajo práctico detrás del mantenimiento de teams-for-linux con IA — desde CLAUDE.md hasta investigación, actualizaciones de dependencias, implementación de funcionalidades y controles de calidad."
+publishedDate: 2026-03-11
+tags: ["IA", "Código Abierto", "Desarrollo de Software", "Teams for Linux"]
+draft: true
+---
+
+## De los principios a la práctica
+
+En [el artículo complementario](/es/articles/ai-assisted-open-source-maintenance) cubrí qué cambia la IA y qué no cuando mantienes un proyecto de código abierto. Este artículo es la continuación práctica: el flujo de trabajo real que uso día a día en teams-for-linux.
+
+Nada de esto es teórico. Es lo que he ido asentando después de meses de iteración, y sigue evolucionando. El patrón central es siempre el mismo: yo decido, la IA ejecuta, y yo reviso todo antes de que se publique.
+
+## CLAUDE.md: el archivo de restricciones
+
+Toda interacción con la herramienta de IA empieza con CLAUDE.md. Es lo primero que el agente lee al abrir el repositorio, y da forma a todo lo que sigue.
+
+El archivo no es largo, pero es denso. Cubre:
+
+**Invariantes arquitectónicos.** El `trayIconRenderer` debe inicializarse antes que `mqttStatusMonitor`. Esta dependencia se ha roto por contribuidores varias veces. Sin CLAUDE.md documentándolo, la IA refactorizaría uno sin considerar al otro sin problemas.
+
+**Límites de módulos.** Qué archivos son responsables de qué. La IA no debería mover funcionalidad entre módulos sin dirección explícita, y el archivo deja claros esos límites.
+
+**Comandos de build y tests.** Cómo ejecutar el proyecto, cómo correr los tests, qué espera el pipeline de CI. Suena básico, pero sin esto la IA adivina — y adivina mal con suficiente frecuencia como para perder tiempo.
+
+**Convenciones de commits.** Etiquetas Co-authored-by, formato de mensajes de commit, nomenclatura de ramas. La IA las sigue automáticamente porque están documentadas.
+
+**Restricciones conocidas.** Peculiaridades de Electron, comportamiento específico de Wayland, restricciones de Trusted Types. Son las minas que atrapan a quien no conoce el código. CLAUDE.md las señaliza.
+
+El archivo es un documento vivo. Cuando descubro un nuevo invariante o un nuevo peligro, va a CLAUDE.md antes que a cualquier otro sitio. La inversión se paga en cada interacción posterior.
+
+## La fase de investigación
+
+La mayoría de cambios no triviales empiezan con investigación, no con código. El flujo es así:
+
+**Describo el problema.** "Los usuarios reportan que la pantalla compartida falla en Wayland con la última actualización de Electron." O "Necesitamos soportar Trusted Types para cumplir con los nuevos requisitos de CSP."
+
+**El agente investiga.** Lee los archivos fuente relevantes, revisa el changelog de Electron, consulta issues upstream y presenta lo que encuentra. Esto es exploración, no implementación. El objetivo es entender.
+
+**Spikes, no soluciones.** Para cualquier cosa no obvia, pido un spike — un prototipo desechable que prueba una hipótesis específica. "¿Podemos interceptar la llamada a desktopCapturer antes de que llegue al path de Wayland?" El spike me dice si un enfoque es viable sin comprometerme con él.
+
+**El agente produce un plan.** Una vez que entendemos el problema y hemos validado un enfoque a través de spikes, el agente escribe un plan estructurado: qué cambios se necesitan, qué archivos se ven afectados, cuáles son los riesgos y qué debería probarse.
+
+**Yo guío, luego el agente ejecuta.** Reviso el plan, ajusto prioridades, señalo riesgos que el agente pasó por alto y doy el visto bueno. Solo entonces empieza la implementación real. Esta secuencia — investigar, spike, planificar, guiar — no es negociable. Saltarse directamente a la implementación es como se acaba escribiendo código que resuelve el problema equivocado.
+
+## Actualizaciones de dependencias
+
+Aquí es donde la asistencia de IA ahorra más tiempo en términos absolutos. El ciclo de actualización de dependencias en teams-for-linux funciona más o menos así:
+
+**Detección.** Dependabot o npm audit señalan una vulnerabilidad o dependencia desactualizada. Esto pasa varias veces por semana.
+
+**Evaluación.** El agente lee el aviso, revisa qué cambió en la dependencia y evalúa si nos afecta. Muchos avisos son para paths de código que no usamos — el agente puede identificarlos rápidamente.
+
+**Actualizar y probar.** El agente sube la versión, ejecuta la suite de tests y comprueba si hay cambios que rompen algo. Para versiones minor y patch, esto suele ser directo. Para versiones major, a menudo desencadena una fase de investigación.
+
+**Las actualizaciones de Electron son especiales.** Las versiones major de Electron rompen cosas regularmente. La actualización implica leer la lista de cambios que rompen compatibilidad, identificar cuáles afectan a nuestro código, hacer spikes de soluciones alternativas para cada uno, y luego implementarlas sistemáticamente. Una sola actualización major de Electron puede tocar docenas de archivos. Sin asistencia de IA, reservaría un fin de semana entero para cada una.
+
+**El criterio de lanzamiento es mío.** El agente puede actualizar, probar y preparar un lanzamiento. Pero la decisión de publicar — si agrupar más correcciones, si el momento es el adecuado, si los usuarios necesitan un aviso previo — esa es mía.
+
+## Implementación de funcionalidades
+
+Cuando una funcionalidad recibe luz verde, el flujo de implementación sigue un patrón consistente:
+
+**Especificación clara primero.** Describo qué debería hacer la funcionalidad, cómo debería comportarse y — igual de importante — qué *no* debería hacer. Los límites de alcance importan. La IA sobreingenierará con gusto si se lo permites.
+
+**Implementación incremental.** Las funcionalidades grandes se dividen en trozos pequeños y revisables. Cada trozo se implementa, prueba y revisa antes de pasar al siguiente. No es solo buena práctica — es esencial cuando trabajas con IA, porque detectar una dirección equivocada pronto cuesta minutos, mientras que detectarla tarde cuesta horas de trabajo desechable.
+
+**Tests junto al código.** El agente escribe tests como parte de la implementación, no como idea tardía. El archivo CLAUDE.md especifica las convenciones de testing, así que los tests siguen los patrones existentes del proyecto.
+
+**Revisar todo.** Cada pieza de código generado por IA se lee. No se ojea — se lee. Busco problemas sutiles: ¿respeta los límites de módulos? ¿Maneja los casos extremos de Electron? ¿Mantiene la compatibilidad hacia atrás donde es necesario? La IA produce buen código la mayor parte del tiempo, pero "la mayor parte del tiempo" no es suficiente para un proyecto con miles de usuarios.
+
+## Gestión de cambios upstream
+
+La webapp de Teams cambia sin aviso. Microsoft no publica un changelog de su cliente web, y la programación defensiva contra esos cambios es una de las partes más difíciles de mantener teams-for-linux.
+
+Cuando algo se rompe, el flujo es:
+
+**Triaje.** Llegan informes de usuarios. El agente ayuda a categorizarlos: ¿es una regresión en nuestro código o Microsoft cambió algo upstream?
+
+**Investigación.** Si es upstream, el agente examina qué cambió — comparando estructuras DOM, peticiones de red o respuestas de API contra lo que esperamos. Este trabajo detectivesco es tedioso y repetitivo, exactamente el tipo de tarea que la IA maneja bien.
+
+**Evaluación.** No todos los cambios upstream se pueden sortear. A veces Microsoft elimina o restringe algo de lo que dependíamos, y ninguna cantidad de código inteligente puede restaurar la funcionalidad. Reconocer cuándo un problema no tiene solución es un juicio humano.
+
+**Solución alternativa o aceptar.** Si existe un workaround, lo implementamos. Si no, lo comunico a los usuarios honestamente. El agente ayuda a redactar la respuesta, pero la decisión y el tono son míos.
+
+## Controles de calidad
+
+Nada se publica sin pasar por un conjunto de controles de calidad. No son aspiracionales — se aplican.
+
+**CI debe pasar.** El pipeline de GitHub Actions ejecuta linting, comprobación de tipos y la suite de tests. Sin excepciones.
+
+**Etiquetas Co-authored-by en cada commit asistido por IA.** Esto es transparencia no negociable. Si la IA ayudó a escribirlo, el commit lo dice.
+
+**Revisión manual de cada cambio.** Leo cada diff antes de que se haga commit. La IA puede proponer cambios, pero yo decido qué entra realmente al código.
+
+**Notas de lanzamiento que explican el "por qué."** El agente redacta las notas de lanzamiento, pero yo las edito para asegurarme de que son útiles para los usuarios — no solo una lista de archivos cambiados, sino una explicación de qué mejoró y por qué importa.
+
+## Lo que he aprendido
+
+Después de meses trabajando así, algunas cosas destacan.
+
+**El flujo de trabajo es el producto.** La herramienta de IA específica importa menos que el proceso que la rodea. Investigar antes de implementar. Spikes antes de comprometerse. Revisar antes de fusionar. Estas prácticas hacen que la asistencia de IA sea efectiva; sin ellas, solo estás generando código más rápido sin generar mejores resultados.
+
+**CLAUDE.md es la inversión de mayor apalancamiento.** Cada hora invertida documentando invariantes, límites y convenciones ahorra muchas horas corrigiendo a la IA después. Es el equivalente a la documentación de onboarding — excepto que la IA realmente la lee cada vez.
+
+**El trabajo del mantenedor cambia, pero no se reduce.** Paso menos tiempo escribiendo boilerplate y más tiempo revisando, decidiendo y comunicando. Las horas totales no han disminuido mucho. Lo que cambió es que esas horas producen más valor.
+
+**La transparencia no cuesta nada.** Ser abierto sobre el uso de IA no ha perjudicado al proyecto. Las etiquetas Co-authored-by y el archivo CLAUDE.md están ahí para que cualquiera los vea. Los usuarios que se preocupan por los resultados — ¿funciona la app, se mantiene, se atienden los issues? — juzgan el proyecto por esos méritos, no por las herramientas usadas.
+
+## Reflexión final
+
+Este flujo de trabajo no es una plantilla. Es lo que funciona para un proyecto específico con un mantenedor específico. Tu versión será diferente — distintas herramientas, distintas restricciones, distintas prioridades.
+
+Pero el patrón subyacente aplica ampliamente: los humanos deciden, la IA ejecuta, los humanos revisan. Sáltate cualquiera de esos pasos y o no estás aprovechando la IA efectivamente o no estás manteniendo la calidad que tus usuarios merecen.
+
+El [artículo de principios](/es/articles/ai-assisted-open-source-maintenance) cubre el porqué. Este artículo cubrió el cómo. Juntos, son la imagen completa de cómo se ve realmente el mantenimiento de código abierto asistido por IA en la práctica.

--- a/src/content/articles/es/ai-assisted-open-source-workflow.mdx
+++ b/src/content/articles/es/ai-assisted-open-source-workflow.mdx
@@ -32,7 +32,7 @@ El archivo es un documento vivo. Cuando descubro un nuevo invariante o un nuevo 
 
 ## La fase de investigación
 
-La mayoría de cambios no triviales empiezan con investigación, no con código. El flujo es así:
+La mayoría de cambios no triviales empiezan con investigación, no con código. El flujo completo es así:
 
 **Describo el problema.** "Los usuarios reportan que la pantalla compartida falla en Wayland con la última actualización de Electron." O "Necesitamos soportar Trusted Types para cumplir con los nuevos requisitos de CSP."
 
@@ -42,7 +42,9 @@ La mayoría de cambios no triviales empiezan con investigación, no con código.
 
 **El agente produce un plan.** Una vez que entendemos el problema y hemos validado un enfoque a través de spikes, el agente escribe un plan estructurado: qué cambios se necesitan, qué archivos se ven afectados, cuáles son los riesgos y qué debería probarse.
 
-**Yo guío, luego el agente ejecuta.** Reviso el plan, ajusto prioridades, señalo riesgos que el agente pasó por alto y doy el visto bueno. Solo entonces empieza la implementación real. Esta secuencia — investigar, spike, planificar, guiar — no es negociable. Saltarse directamente a la implementación es como se acaba escribiendo código que resuelve el problema equivocado.
+**Yo guío, luego el agente ejecuta.** Reviso el plan, ajusto prioridades, señalo riesgos que el agente pasó por alto y doy el visto bueno. Solo entonces empieza la implementación real.
+
+No todos los cambios necesitan la secuencia completa. Una corrección de bug directa puede saltarse el spike e ir directamente de la investigación a la implementación. Una actualización compleja de Electron puede necesitar múltiples rondas de spikes a lo largo de varias sesiones. El proceso se adapta al problema. Lo que no cambia es que entiendo lo que está pasando antes de comprometerme con un enfoque.
 
 ## Actualizaciones de dependencias
 
@@ -69,6 +71,30 @@ Cuando una funcionalidad recibe luz verde, el flujo de implementación sigue un 
 **Tests junto al código.** El agente escribe tests como parte de la implementación, no como idea tardía. El archivo CLAUDE.md especifica las convenciones de testing, así que los tests siguen los patrones existentes del proyecto.
 
 **Revisar todo.** Cada pieza de código generado por IA se lee. No se ojea — se lee. Busco problemas sutiles: ¿respeta los límites de módulos? ¿Maneja los casos extremos de Electron? ¿Mantiene la compatibilidad hacia atrás donde es necesario? La IA produce buen código la mayor parte del tiempo, pero "la mayor parte del tiempo" no es suficiente para un proyecto con miles de usuarios.
+
+## Mantener el contexto limpio
+
+Cuando una implementación está terminada, sigo una práctica tradicional: el resultado se almacena como un ADR (Architecture Decision Record). El documento de investigación que llevó a él se elimina.
+
+Puede sonar derrochador — ¿por qué tirar la investigación? — pero es deliberado. La investigación siempre es recuperable del historial de git si la necesito. Lo que importa es mantener limpio el contexto actual. Si los documentos de investigación viejos se acumulan en el repositorio, la IA los lee y se confunde sobre qué es actual versus qué es histórico. Empieza a referenciar resultados de spikes obsoletos o planes superados.
+
+El ADR captura la decisión y su justificación. Eso es lo que las sesiones futuras necesitan. El camino desordenado que llevó hasta ahí — los callejones sin salida, los spikes descartados, los enfoques abandonados — es ruido una vez que la decisión está tomada. Git lo recuerda. El directorio de trabajo no necesita hacerlo.
+
+## Tipos de sesión
+
+El flujo de investigación-a-implementación no es el único tipo de sesión que ejecuto. El mantenimiento implica varios tipos de sesiones recurrentes, cada uno con su propio foco:
+
+**Sesiones de seguridad.** Revisar resultados de npm audit, evaluar avisos, parchear vulnerabilidades. Se ejecutan frecuentemente porque el ecosistema npm nunca deja de producir avisos.
+
+**Limpieza de documentación.** Actualizar secciones del README, limpiar comentarios inline que se han desviado del código, refrescar CLAUDE.md con nuevos invariantes descubiertos desde la última pasada.
+
+**Métricas y revisiones de salud.** Revisar tendencias de issues, actividad de contribuidores, tiempos de build, cambios en cobertura de tests. Entender la trayectoria del proyecto, no solo el estado actual.
+
+**Actualizaciones de dependencias.** El ciclo descrito arriba — detección, evaluación, actualización, prueba, decisión de lanzamiento.
+
+Cada tipo de sesión sigue el mismo patrón central: yo establezco el alcance, la IA ejecuta dentro de él, yo reviso los resultados. La diferencia es a qué estamos mirando, no cómo trabajamos.
+
+Ahora mismo estas sesiones se ejecutan cuando llego a ellas. Me gustaría semi-automatizar las recurrentes — tener un informe mensual generado que muestre tendencias, señale cosas que necesitan atención y me dé una foto sin tener que acordarme de mirar. El bot de triaje ya hace una versión de esto para los issues. Extender ese patrón a la postura de seguridad, la frescura de dependencias y la deriva de documentación es el siguiente paso natural.
 
 ## Gestión de cambios upstream
 

--- a/src/content/articles/es/ai-assisted-open-source-workflow.mdx
+++ b/src/content/articles/es/ai-assisted-open-source-workflow.mdx
@@ -82,7 +82,7 @@ El ADR captura la decisión y su justificación. Eso es lo que las sesiones futu
 
 ## Tipos de sesión
 
-El flujo de investigación-a-implementación no es el único tipo de sesión que ejecuto. El mantenimiento implica varios tipos de sesiones recurrentes, cada uno con su propio foco:
+Las actualizaciones de dependencias son el tipo de sesión más frecuente, pero no el único. Más allá del ciclo descrito arriba, hay otros tipos recurrentes que componen la mayor parte del mantenimiento:
 
 **Sesiones de seguridad.** Revisar resultados de npm audit, evaluar avisos, parchear vulnerabilidades. Se ejecutan frecuentemente porque el ecosistema npm nunca deja de producir avisos.
 
@@ -90,9 +90,7 @@ El flujo de investigación-a-implementación no es el único tipo de sesión que
 
 **Métricas y revisiones de salud.** Revisar tendencias de issues, actividad de contribuidores, tiempos de build, cambios en cobertura de tests. Entender la trayectoria del proyecto, no solo el estado actual.
 
-**Actualizaciones de dependencias.** El ciclo descrito arriba — detección, evaluación, actualización, prueba, decisión de lanzamiento.
-
-Cada tipo de sesión sigue el mismo patrón central: yo establezco el alcance, la IA ejecuta dentro de él, yo reviso los resultados. La diferencia es a qué estamos mirando, no cómo trabajamos.
+Cada tipo de sesión — incluidas las actualizaciones de dependencias — sigue el mismo patrón central: yo establezco el alcance, la IA ejecuta dentro de él, yo reviso los resultados. La diferencia es a qué estamos mirando, no cómo trabajamos.
 
 Ahora mismo estas sesiones se ejecutan cuando llego a ellas. Me gustaría semi-automatizar las recurrentes — tener un informe mensual generado que muestre tendencias, señale cosas que necesitan atención y me dé una foto sin tener que acordarme de mirar. El bot de triaje ya hace una versión de esto para los issues. Extender ese patrón a la postura de seguridad, la frescura de dependencias y la deriva de documentación es el siguiente paso natural.
 

--- a/src/content/articles/es/ai-assisted-open-source-workflow.mdx
+++ b/src/content/articles/es/ai-assisted-open-source-workflow.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Código abierto asistido por IA: el flujo de trabajo"
-description: "El flujo de trabajo práctico detrás del mantenimiento de teams-for-linux con IA — desde CLAUDE.md hasta investigación, actualizaciones de dependencias, implementación de funcionalidades y controles de calidad."
+description: "El flujo de trabajo práctico detrás del mantenimiento de teams-for-linux con IA: desde CLAUDE.md hasta investigación, actualizaciones de dependencias, implementación de funcionalidades y controles de calidad."
 publishedDate: 2026-03-11
 tags: ["IA", "Código Abierto", "Desarrollo de Software", "Teams for Linux"]
 draft: true
@@ -8,134 +8,44 @@ draft: true
 
 ## De los principios a la práctica
 
-En [el artículo complementario](/es/articles/ai-assisted-open-source-maintenance) cubrí qué cambia la IA y qué no al mantener un proyecto de código abierto. Este artículo es la continuación práctica: el flujo de trabajo real que uso día a día en teams-for-linux.
+El [artículo complementario](/es/articles/ai-assisted-open-source-maintenance) cubrió qué cambia la IA al mantener un proyecto open source. Este es el flujo de trabajo del día a día. El patrón central siempre es el mismo: yo decido, la IA ejecuta, yo reviso. Nada de esto es teórico. Es lo que me ha quedado tras meses de iteración, y sigue evolucionando.
 
-Nada de esto es teórico. Es lo que he ido asentando después de meses de iteración, y sigue evolucionando. El patrón central es siempre el mismo: yo decido, la IA ejecuta, y yo reviso todo antes de que se publique.
+## CLAUDE.md como documento vivo
 
-## CLAUDE.md: el archivo de restricciones
+Cada interacción empieza con CLAUDE.md. El archivo es corto pero denso: invariantes arquitectónicas, fronteras entre módulos, comandos de build y test, convenciones de commit, restricciones conocidas como las peculiaridades de Electron o el comportamiento específico de Wayland. Por ejemplo, este proyecto prohíbe loguear cualquier cosa sensible como URLs de broker, direcciones de email o tokens de autenticación. Es exactamente el tipo de detalle que una IA esparcirá amablemente por llamadas a `console.info` a menos que le digas que no. Cuando descubro un nuevo invariante o footgun, va al archivo antes que nada. La inversión se amortiza en cada interacción posterior.
 
-Toda interacción con la herramienta de IA empieza con CLAUDE.md. Es lo primero que el agente lee al abrir el repositorio, y da forma a todo lo que sigue.
+## Investigar antes de programar
 
-El archivo no es largo, pero es denso. Cubre:
-
-**Invariantes arquitectónicos.** El `trayIconRenderer` debe inicializarse antes que `mqttStatusMonitor`. Esta dependencia se ha roto por contribuidores varias veces. Sin CLAUDE.md documentándolo, la IA refactorizaría uno sin considerar al otro sin problemas.
-
-**Límites de módulos.** Qué archivos son responsables de qué. La IA no debería mover funcionalidad entre módulos sin dirección explícita, y el archivo deja claros esos límites.
-
-**Comandos de build y tests.** Cómo ejecutar el proyecto, cómo correr los tests, qué espera el pipeline de CI. Suena básico, pero sin esto la IA adivina — y adivina mal con suficiente frecuencia como para perder tiempo.
-
-**Convenciones de commits.** Etiquetas Co-authored-by, formato de mensajes de commit, nomenclatura de ramas. La IA las sigue automáticamente porque están documentadas.
-
-**Restricciones conocidas.** Peculiaridades de Electron, comportamiento específico de Wayland, restricciones de Trusted Types. Son las minas que atrapan a quien no conoce el código. CLAUDE.md las señaliza.
-
-El archivo es un documento vivo. Cuando descubro un nuevo invariante o un nuevo peligro, va a CLAUDE.md antes que a cualquier otro sitio. La inversión se paga en cada interacción posterior.
-
-## La fase de investigación
-
-La mayoría de cambios no triviales empiezan con investigación, no con código. El flujo completo es así:
-
-**Describo el problema.** "Los usuarios reportan que la pantalla compartida falla en Wayland con la última actualización de Electron." O "Necesitamos soportar Trusted Types para cumplir con los nuevos requisitos de CSP."
-
-**El agente investiga.** Lee los archivos fuente relevantes, revisa el changelog de Electron, consulta issues upstream y presenta lo que encuentra. Esto es exploración, no implementación. El objetivo es entender.
-
-**Spikes, no soluciones.** Para cualquier cosa no obvia, pido un spike — un prototipo desechable que prueba una hipótesis específica. "¿Podemos interceptar la llamada a desktopCapturer antes de que llegue al path de Wayland?" El spike me dice si un enfoque es viable sin comprometerme con él.
-
-**El agente produce un plan.** Una vez que entendemos el problema y hemos validado un enfoque a través de spikes, el agente escribe un plan estructurado: qué cambios se necesitan, qué archivos se ven afectados, cuáles son los riesgos y qué debería probarse.
-
-**Yo guío, luego el agente ejecuta.** Reviso el plan, ajusto prioridades, señalo riesgos que el agente pasó por alto y doy el visto bueno. Solo entonces empieza la implementación real.
-
-No todos los cambios necesitan la secuencia completa. Una corrección de bug directa puede saltarse el spike e ir directamente de la investigación a la implementación. Una actualización compleja de Electron puede necesitar múltiples rondas de spikes a lo largo de varias sesiones. El proceso se adapta al problema. Lo que no cambia es que entiendo lo que está pasando antes de comprometerme con un enfoque.
+La mayoría de los cambios no triviales empiezan con investigación, no con implementación. Describo el problema ("la pantalla compartida falla en Wayland con la última actualización de Electron"); el agente investiga el código relevante, el changelog y los issues upstream. Para cualquier cosa no obvia pido un spike: un prototipo desechable que prueba una hipótesis concreta. Una vez que un enfoque es viable, el agente escribe un plan. Lo reviso, marco riesgos, y solo entonces empieza la implementación. Los bugs simples se saltan el spike; las actualizaciones complejas de Electron necesitan varias rondas. El proceso se adapta; lo que no cambia es que entiendo qué está pasando antes de comprometerme con un enfoque.
 
 ## Actualizaciones de dependencias
 
-Aquí es donde la asistencia de IA ahorra más tiempo en términos absolutos. El ciclo de actualización de dependencias en teams-for-linux funciona más o menos así:
+Aquí es donde la asistencia de IA ahorra más tiempo. Dependabot o npm audit marca algo; el agente lee el aviso, comprueba qué cambió, y juzga si nos afecta. Muchos avisos son para rutas de código que no usamos. Las versiones menores y de parche suelen ser sencillas. Las versiones mayores a menudo desencadenan una fase de investigación. Las mayores de Electron son especiales: tocan rutinariamente decenas de archivos, y sin IA presupuestaría un fin de semana entero por actualización. La decisión de lanzamiento, si lanzar ahora o agrupar más correcciones, sigue siendo mía.
 
-**Detección.** Dependabot o npm audit señalan una vulnerabilidad o dependencia desactualizada. Esto pasa varias veces por semana.
+## Funcionalidades y el hábito de contexto limpio
 
-**Evaluación.** El agente lee el aviso, revisa qué cambió en la dependencia y evalúa si nos afecta. Muchos avisos son para paths de código que no usamos — el agente puede identificarlos rápidamente.
+Cuando una funcionalidad recibe luz verde, el flujo es consistente: especificación clara incluyendo lo que *no* hay que hacer, implementación incremental en trozos revisables, tests escritos en paralelo (la IA sigue los patrones documentados en CLAUDE.md) y una lectura completa de cada diff. La IA produce buen código la mayor parte del tiempo, pero "la mayor parte del tiempo" no es suficiente para miles de usuarios.
 
-**Actualizar y probar.** El agente sube la versión, ejecuta la suite de tests y comprueba si hay cambios que rompen algo. Para versiones minor y patch, esto suele ser directo. Para versiones major, a menudo desencadena una fase de investigación.
+Cuando el trabajo termina, el resultado se convierte en un ADR. La investigación que lo llevó allí se borra. Git recuerda los callejones sin salida; el directorio de trabajo no necesita hacerlo. Los documentos de investigación viejos se acumulan, se vuelven a leer y confunden a la IA sobre qué es actual y qué es histórico.
 
-**Las actualizaciones de Electron son especiales.** Las versiones major de Electron rompen cosas regularmente. La actualización implica leer la lista de cambios que rompen compatibilidad, identificar cuáles afectan a nuestro código, hacer spikes de soluciones alternativas para cada uno, y luego implementarlas sistemáticamente. Una sola actualización major de Electron puede tocar docenas de archivos. Sin asistencia de IA, reservaría un fin de semana entero para cada una.
+## Otras sesiones recurrentes
 
-**El criterio de lanzamiento es mío.** El agente puede actualizar, probar y preparar un lanzamiento. Pero la decisión de publicar — si agrupar más correcciones, si el momento es el adecuado, si los usuarios necesitan un aviso previo — esa es mía.
+Las actualizaciones de dependencias son el tipo de sesión más frecuente, pero no el único. Las sesiones de seguridad evalúan y parchean avisos. Las pasadas de documentación actualizan READMEs y refrescan CLAUDE.md con invariantes recién descubiertos. Las sesiones de métricas miran tendencias de issues, actividad de contribuidores, tiempos de build, cambios en cobertura de tests. Cada una sigue la misma forma: yo establezco el alcance, la IA ejecuta, yo reviso.
 
-## Implementación de funcionalidades
+## Gestionar cambios upstream
 
-Cuando una funcionalidad recibe luz verde, el flujo de implementación sigue un patrón consistente:
-
-**Especificación clara primero.** Describo qué debería hacer la funcionalidad, cómo debería comportarse y — igual de importante — qué *no* debería hacer. Los límites de alcance importan. La IA sobreingenierará con gusto si se lo permites.
-
-**Implementación incremental.** Las funcionalidades grandes se dividen en trozos pequeños y revisables. Cada trozo se implementa, prueba y revisa antes de pasar al siguiente. No es solo buena práctica — es esencial cuando trabajas con IA, porque detectar una dirección equivocada pronto cuesta minutos, mientras que detectarla tarde cuesta horas de trabajo desechable.
-
-**Tests junto al código.** El agente escribe tests como parte de la implementación, no como idea tardía. El archivo CLAUDE.md especifica las convenciones de testing, así que los tests siguen los patrones existentes del proyecto.
-
-**Revisar todo.** Cada pieza de código generado por IA se lee. No se ojea — se lee. Busco problemas sutiles: ¿respeta los límites de módulos? ¿Maneja los casos extremos de Electron? ¿Mantiene la compatibilidad hacia atrás donde es necesario? La IA produce buen código la mayor parte del tiempo, pero "la mayor parte del tiempo" no es suficiente para un proyecto con miles de usuarios.
-
-## Mantener el contexto limpio
-
-Cuando una implementación está terminada, sigo una práctica tradicional: el resultado se almacena como un ADR (Architecture Decision Record). El documento de investigación que llevó a él se elimina.
-
-Puede sonar derrochador — ¿por qué tirar la investigación? — pero es deliberado. La investigación siempre es recuperable del historial de git si la necesito. Lo que importa es mantener limpio el contexto actual. Si los documentos de investigación viejos se acumulan en el repositorio, la IA los lee y se confunde sobre qué es actual versus qué es histórico. Empieza a referenciar resultados de spikes obsoletos o planes superados.
-
-El ADR captura la decisión y su justificación. Eso es lo que las sesiones futuras necesitan. El camino desordenado que llevó hasta ahí — los callejones sin salida, los spikes descartados, los enfoques abandonados — es ruido una vez que la decisión está tomada. Git lo recuerda. El directorio de trabajo no necesita hacerlo.
-
-## Tipos de sesión
-
-Las actualizaciones de dependencias son el tipo de sesión más frecuente, pero no el único. Más allá del ciclo descrito arriba, hay otros tipos recurrentes que componen la mayor parte del mantenimiento:
-
-**Sesiones de seguridad.** Revisar resultados de npm audit, evaluar avisos, parchear vulnerabilidades. Se ejecutan frecuentemente porque el ecosistema npm nunca deja de producir avisos.
-
-**Limpieza de documentación.** Actualizar secciones del README, limpiar comentarios inline que se han desviado del código, refrescar CLAUDE.md con nuevos invariantes descubiertos desde la última pasada.
-
-**Métricas y revisiones de salud.** Revisar tendencias de issues, actividad de contribuidores, tiempos de build, cambios en cobertura de tests. Entender la trayectoria del proyecto, no solo el estado actual.
-
-Cada tipo de sesión — incluidas las actualizaciones de dependencias — sigue el mismo patrón central: yo establezco el alcance, la IA ejecuta dentro de él, yo reviso los resultados. La diferencia es a qué estamos mirando, no cómo trabajamos.
-
-Ahora mismo estas sesiones se ejecutan cuando llego a ellas. Me gustaría semi-automatizar las recurrentes — tener un informe mensual generado que muestre tendencias, señale cosas que necesitan atención y me dé una foto sin tener que acordarme de mirar. El bot de triaje ya hace una versión de esto para los issues. Extender ese patrón a la postura de seguridad, la frescura de dependencias y la deriva de documentación es el siguiente paso natural.
-
-## Gestión de cambios upstream
-
-La webapp de Teams cambia sin aviso. Microsoft no publica un changelog de su cliente web, y la programación defensiva contra esos cambios es una de las partes más difíciles de mantener teams-for-linux.
-
-Cuando algo se rompe, el flujo es:
-
-**Triaje.** Llegan informes de usuarios. El agente ayuda a categorizarlos: ¿es una regresión en nuestro código o Microsoft cambió algo upstream?
-
-**Investigación.** Si es upstream, el agente examina qué cambió — comparando estructuras DOM, peticiones de red o respuestas de API contra lo que esperamos. Este trabajo detectivesco es tedioso y repetitivo, exactamente el tipo de tarea que la IA maneja bien.
-
-**Evaluación.** No todos los cambios upstream se pueden sortear. A veces Microsoft elimina o restringe algo de lo que dependíamos, y ninguna cantidad de código inteligente puede restaurar la funcionalidad. Reconocer cuándo un problema no tiene solución es un juicio humano.
-
-**Solución alternativa o aceptar.** Si existe un workaround, lo implementamos. Si no, lo comunico a los usuarios honestamente. El agente ayuda a redactar la respuesta, pero la decisión y el tono son míos.
+La web app de Teams cambia sin previo aviso, y programar defensivamente contra esos cambios es una de las partes más difíciles de este proyecto. Cuando algo se rompe, el agente me ayuda a categorizar. ¿Es una regresión nuestra o un cambio upstream? Después investiga diferencias en DOM, red o respuestas de API. Algunos cambios tienen workaround; otros no. Reconocer cuándo un problema no tiene solución es una decisión humana, y la respuesta a los usuarios es mía.
 
 ## Controles de calidad
 
-Nada se publica sin pasar por un conjunto de controles de calidad. No son aspiracionales — se aplican.
+Nada se lanza sin pasar los controles aplicados: CI tiene que pasar (linting, type checking, suite de tests completa, sin excepciones), cada commit asistido por IA lleva una etiqueta `Co-authored-by`, cada diff se lee manualmente, y las release notes se editan para explicar el *porqué* en lugar de listar archivos.
 
-**CI debe pasar.** El pipeline de GitHub Actions ejecuta linting, comprobación de tipos y la suite de tests. Sin excepciones.
+## Trátalo como un equipo
 
-**Etiquetas Co-authored-by en cada commit asistido por IA.** Esto es transparencia no negociable. Si la IA ayudó a escribirlo, el commit lo dice.
-
-**Revisión manual de cada cambio.** Leo cada diff antes de que se haga commit. Sin excepciones para el código generado por IA.
-
-**Notas de lanzamiento que explican el "por qué."** El agente redacta las notas de lanzamiento, pero yo las edito para asegurarme de que son útiles para los usuarios — no solo una lista de archivos cambiados, sino una explicación de qué mejoró y por qué importa.
-
-## Lo que he aprendido
-
-Después de meses trabajando así, algunas cosas destacan.
-
-**El flujo de trabajo es el producto.** La herramienta de IA específica importa menos que el proceso que la rodea. Investigar antes de implementar. Spikes antes de comprometerse. Revisar antes de fusionar. Estas prácticas hacen que la asistencia de IA sea efectiva; sin ellas, solo estás generando código más rápido sin generar mejores resultados.
-
-**CLAUDE.md es la inversión de mayor apalancamiento.** Cada hora invertida documentando invariantes, límites y convenciones ahorra muchas horas corrigiendo a la IA después. Es el equivalente a la documentación de onboarding — excepto que la IA realmente la lee cada vez.
-
-**El trabajo del mantenedor cambia, pero no se reduce.** Paso menos tiempo escribiendo boilerplate y más tiempo revisando, decidiendo y comunicando. Las horas totales no han disminuido mucho. Lo que cambió es que esas horas producen más valor.
-
-**Trátalo como un equipo, no como una herramienta.** Casi tienes que hacerlo. Una vez que has construido suficientes restricciones alrededor de la IA — CLAUDE.md, el ciclo de investigación-luego-spike, la revisión manual, los controles de CI — ya no estás realmente usando una herramienta, estás dirigiendo un sistema. El patrón es el mismo que aplicarías a cualquier software que crece: construir confianza con datos, añadir solidez a medida que avanzas, simplificar o quitar lo que deja de ganarse su sitio. La diferencia es que los ciclos van más rápido.
+Una vez que has construido suficientes restricciones alrededor de la IA (CLAUDE.md, el ciclo de investigación-luego-spike, la revisión manual, los controles de CI), ya no estás usando una herramienta. Estás dirigiendo un sistema. El patrón es el mismo que aplicarías a cualquier software que crece: construir confianza con datos, añadir solidez a medida que avanzas, simplificar o quitar lo que deja de ganarse su sitio. La diferencia es que los ciclos van más rápido.
 
 ## Reflexión final
 
-Este flujo de trabajo no es una plantilla. Es lo que funciona para un proyecto específico con un mantenedor específico. Tu versión será diferente — distintas herramientas, distintas restricciones, distintas prioridades.
+Este flujo de trabajo no es una plantilla. Es lo que funciona para un proyecto específico con un mantenedor específico. Tu versión será diferente. Pero el patrón subyacente es portable: un humano al principio, un humano al final, la herramienta en medio. Salta cualquiera de esos extremos y o no estás aprovechando la IA efectivamente o no estás manteniendo la calidad que tus usuarios merecen.
 
-Pero el patrón subyacente es portable: un humano al principio, un humano al final, la herramienta en medio. Salta cualquiera de esos extremos y o no estás aprovechando la IA efectivamente o no estás manteniendo la calidad que tus usuarios merecen.
-
-El [artículo de principios](/es/articles/ai-assisted-open-source-maintenance) cubre el porqué. Este artículo cubrió el cómo. Juntos, son la imagen completa de cómo se ve realmente el mantenimiento de código abierto asistido por IA en la práctica.
+El [artículo de principios](/es/articles/ai-assisted-open-source-maintenance) cubrió el porqué. Este artículo cubrió el cómo. Juntos son la imagen completa.

--- a/src/content/articles/es/ai-assisted-open-source-workflow.mdx
+++ b/src/content/articles/es/ai-assisted-open-source-workflow.mdx
@@ -116,7 +116,7 @@ Nada se publica sin pasar por un conjunto de controles de calidad. No son aspira
 
 **Etiquetas Co-authored-by en cada commit asistido por IA.** Esto es transparencia no negociable. Si la IA ayudó a escribirlo, el commit lo dice.
 
-**Revisión manual de cada cambio.** Leo cada diff antes de que se haga commit. La IA puede proponer cambios, pero yo decido qué entra realmente al código.
+**Revisión manual de cada cambio.** Leo cada diff antes de que se haga commit. Sin excepciones para el código generado por IA.
 
 **Notas de lanzamiento que explican el "por qué."** El agente redacta las notas de lanzamiento, pero yo las edito para asegurarme de que son útiles para los usuarios — no solo una lista de archivos cambiados, sino una explicación de qué mejoró y por qué importa.
 
@@ -130,7 +130,7 @@ Después de meses trabajando así, algunas cosas destacan.
 
 **El trabajo del mantenedor cambia, pero no se reduce.** Paso menos tiempo escribiendo boilerplate y más tiempo revisando, decidiendo y comunicando. Las horas totales no han disminuido mucho. Lo que cambió es que esas horas producen más valor.
 
-**Trabajar a la vista te enseña cosas.** Las etiquetas Co-authored-by y el archivo CLAUDE.md están ahí para que cualquiera los vea. Esa visibilidad convierte el proyecto en un experimento de aprendizaje — qué cambios asistidos por IA funcionan bien, cuáles generan fricción, qué le importa realmente a la comunidad. No puedes aprender nada de eso si ocultas el proceso.
+**Trátalo como un equipo, no como una herramienta.** Casi tienes que hacerlo. Una vez que has construido suficientes restricciones alrededor de la IA — CLAUDE.md, el ciclo de investigación-luego-spike, la revisión manual, los controles de CI — ya no estás realmente usando una herramienta, estás dirigiendo un sistema. El patrón es el mismo que aplicarías a cualquier software que crece: construir confianza con datos, añadir solidez a medida que avanzas, simplificar o quitar lo que deja de ganarse su sitio. La diferencia es que los ciclos van más rápido.
 
 ## Reflexión final
 

--- a/src/content/articles/es/ai-assisted-open-source-workflow.mdx
+++ b/src/content/articles/es/ai-assisted-open-source-workflow.mdx
@@ -136,6 +136,6 @@ Después de meses trabajando así, algunas cosas destacan.
 
 Este flujo de trabajo no es una plantilla. Es lo que funciona para un proyecto específico con un mantenedor específico. Tu versión será diferente — distintas herramientas, distintas restricciones, distintas prioridades.
 
-Pero el patrón subyacente aplica ampliamente: los humanos deciden, la IA ejecuta, los humanos revisan. Sáltate cualquiera de esos pasos y o no estás aprovechando la IA efectivamente o no estás manteniendo la calidad que tus usuarios merecen.
+Pero el patrón subyacente es portable: un humano al principio, un humano al final, la herramienta en medio. Salta cualquiera de esos extremos y o no estás aprovechando la IA efectivamente o no estás manteniendo la calidad que tus usuarios merecen.
 
 El [artículo de principios](/es/articles/ai-assisted-open-source-maintenance) cubre el porqué. Este artículo cubrió el cómo. Juntos, son la imagen completa de cómo se ve realmente el mantenimiento de código abierto asistido por IA en la práctica.

--- a/src/content/articles/es/ai-assisted-open-source-workflow.mdx
+++ b/src/content/articles/es/ai-assisted-open-source-workflow.mdx
@@ -8,7 +8,7 @@ draft: true
 
 ## De los principios a la práctica
 
-En [el artículo complementario](/es/articles/ai-assisted-open-source-maintenance) cubrí qué cambia la IA y qué no cuando mantienes un proyecto de código abierto. Este artículo es la continuación práctica: el flujo de trabajo real que uso día a día en teams-for-linux.
+En [el artículo complementario](/es/articles/ai-assisted-open-source-maintenance) cubrí qué cambia la IA y qué no al mantener un proyecto de código abierto. Este artículo es la continuación práctica: el flujo de trabajo real que uso día a día en teams-for-linux.
 
 Nada de esto es teórico. Es lo que he ido asentando después de meses de iteración, y sigue evolucionando. El patrón central es siempre el mismo: yo decido, la IA ejecuta, y yo reviso todo antes de que se publique.
 


### PR DESCRIPTION
## Summary

Adds `docs/plans/2026-05-12-claude-md-review.md` so the upcoming review of the user's global `CLAUDE.md` gets picked up by the `/roadmap` skill in a fresh session. No code or content changes; planning doc only.

The entry captures one specific conflict already surfaced this session (the new "run /address-pr-comments after opening a PR" rule vs the older "anything past opening a PR requires user confirmation" rule) and sets the constraints for the executor: use `/claude-md-management:claude-md-improver`, dispatch parallel agents where useful, delegate to ollama (prefer MLX-backed models on this hardware), open issues in `delegate-to-ollama` for any new failure modes observed.

## Test plan

- [ ] File renders correctly in the dev server if surfaced anywhere (it isn't; `docs/plans` is not part of the Astro content).
- [ ] `/roadmap` in a fresh session lists this entry.