### PR TITLE
chore: add CNAME for custom domain (ismaelmartinez.me.uk)

### DIFF
--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+ismaelmartinez.me.uk


### PR DESCRIPTION
Adds `public/CNAME` so the site serves from `ismaelmartinez.me.uk` and the GitHub Pages custom-domain binding survives deploys.

## Why
DNS is now configured in Route 53 (A + AAAA records → GitHub Pages, NS delegation verified). This repo deploys via the peaceiris action, which republishes `dist/` to `gh-pages` on every run; without a CNAME in `dist/`, a deploy would wipe a domain set via the Settings → Pages UI. Astro copies `public/` into `dist/`, so this file keeps the binding stable.

## After merge
Set the custom domain to `ismaelmartinez.me.uk` in Settings → Pages (if not already), let the certificate provision, then enable "Enforce HTTPS".

🤖 Generated with [Claude Code](https://claude.com/claude-code)