### PR TITLE
test: fix rotting dates in health tier fixtures

### DIFF
--- a/tests/data/health.test.ts
+++ b/tests/data/health.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import { parsePortfolioSnapshot } from '../../src/data/health';
 
+// Dates relative to "now" so freshness checks (release ≤ 90d, push ≤ 180d)
+// stay stable over time instead of rotting against hardcoded dates.
+const daysAgoIso = (days: number) => new Date(Date.now() - days * 86_400_000).toISOString();
+
 const validSnapshot = {
   schema_version: 'v1' as const,
   repos: {
@@ -16,8 +20,8 @@ const validSnapshot = {
       codeScanning: null,
       secretScanning: { count: 0 },
       ci: 4,
-      released_at: '2026-03-01T00:00:00Z',
-      pushed_at: '2026-04-01T00:00:00Z',
+      released_at: daysAgoIso(30),
+      pushed_at: daysAgoIso(30),
       computed: {
         tier: 'gold' as const,
         checks: [{ name: 'Has CI workflows (2+)', passed: true, required_for: 'gold' }],
@@ -62,8 +66,8 @@ describe('parsePortfolioSnapshot', () => {
         codeScanning: null,
         secretScanning: { count: 0 },
         ci: 3,
-        released_at: '2026-03-01T00:00:00Z',
-        pushed_at: '2026-04-01T00:00:00Z',
+        released_at: daysAgoIso(60),
+        pushed_at: daysAgoIso(60),
       },
     };
     const result = parsePortfolioSnapshot(legacySnapshot);


### PR DESCRIPTION
The `validate` CI job has been failing on `main` (and therefore on every open PR) since 2026-05-30.

## Root cause
`tests/data/health.test.ts` hardcoded `released_at: '2026-03-01'`. The gold-tier check in `health.ts` requires a release within the last 90 days (`daysSinceRelease <= 90`). That threshold elapsed on 2026-05-30, so the fixture dropped from `gold` to `silver` and the assertion at line 86 began failing. The legacy fixture's `pushed_at` was the same trap due to fire in late September (silver's 180-day activity check).

## Fix
Compute fixture dates relative to `Date.now()` via a `daysAgoIso()` helper, so freshness checks stay stable over time. No production code changed.

## Verification
Full suite green (57/57), lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)