### PR TITLE
Harden security: pin CodeQL actions, add Vercel headers, extend CSP

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,8 +15,8 @@ jobs:
       security-events: write
       contents: read
     steps:
-      - uses: actions/checkout@v6
-      - uses: github/codeql-action/init@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
           languages: javascript-typescript
-      - uses: github/codeql-action/analyze@v4
+      - uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2

--- a/docs/security-review-2026-06-09.md
+++ b/docs/security-review-2026-06-09.md
@@ -1,0 +1,61 @@
+# Security Review — 2026-06-09
+
+Full-repository security review of the Astro static site. Overall posture: **good**.
+The findings below were either fixed in the accompanying commit or accepted with rationale.
+
+## Summary
+
+| Area | Status | Notes |
+|------|--------|-------|
+| GitHub Actions — SHA pinning | ✅ Fixed | `ci.yml`/`gh-pages.yml` were already pinned; `codeql.yml` used floating tags — now pinned |
+| GitHub Actions — permissions | ✅ Good | Least-privilege `permissions:` blocks on every workflow |
+| Workflow injection | ✅ Good | No `pull_request_target`, no untrusted `${{ }}` interpolation in `run:` steps |
+| Security headers (Vercel) | ✅ Fixed | `vercel.json` had no headers — HSTS, X-Frame-Options, nosniff, Referrer-Policy, Permissions-Policy added |
+| Content Security Policy | ✅ Hardened | Added `object-src 'none'`, `base-uri 'self'`, `form-action 'self'`, `upgrade-insecure-requests` |
+| `set:html` usage | ✅ Safe | Both instances are `JSON.stringify` output into non-executable script types; JSON-LD additionally escapes `<` |
+| `innerHTML` / `eval` / `Function()` | ✅ Absent | None in `src/` |
+| External links | ✅ Good | All `target="_blank"` links carry `rel="noopener noreferrer"` |
+| Secrets | ✅ Clean | No credentials committed; the Umami `data-website-id` is a public analytics identifier, not a secret |
+| Dependencies | ✅ Good | Four runtime deps, all Astro-official; Dependabot weekly with grouped updates |
+| `scripts/check-links.js` | ✅ Safe | Pure `fs` operations, no shell execution, external URLs skipped |
+| localStorage | ✅ Safe | Theme preference and game high scores only |
+| MDX content | ✅ Safe | No embedded scripts, iframes, or objects in articles |
+
+## Fixes applied in this review
+
+1. **Pinned CodeQL workflow actions to commit SHAs** (`.github/workflows/codeql.yml`).
+   Floating tags (`@v4`, `@v6`) can be retargeted upstream — a supply-chain risk.
+   Now pinned to `actions/checkout` v6.0.2 and `github/codeql-action` v4.36.2,
+   matching the convention already used in `ci.yml` and `gh-pages.yml`. Dependabot
+   keeps pinned SHAs updated.
+
+2. **Added HTTP security headers to `vercel.json`**: `Strict-Transport-Security`,
+   `X-Frame-Options: DENY`, `X-Content-Type-Options`, `Referrer-Policy`, and
+   `Permissions-Policy`. These apply to the Vercel mirror; see "accepted risks"
+   for the GitHub Pages caveat.
+
+3. **Hardened the meta CSP** in `src/layouts/Layout.astro` with
+   `object-src 'none'`, `base-uri 'self'`, `form-action 'self'`, and
+   `upgrade-insecure-requests`.
+
+## Accepted risks / known limitations
+
+- **`'unsafe-inline'` in `script-src` and `style-src`**: required by Astro's
+  architecture — the theme FOUC guard, `ClientRouter`, scoped component styles,
+  and the game pages all rely on inline scripts/styles. Risk is mitigated by the
+  site being fully static with no user-generated content reflected into pages.
+  Revisit if Astro gains first-class nonce/hash support for static output.
+- **No clickjacking protection on GitHub Pages**: `frame-ancestors` is ignored in
+  meta CSP and `X-Frame-Options` cannot be set as a meta tag. GitHub Pages does
+  not allow custom response headers. The Vercel deployment is protected; the
+  primary GH Pages deployment accepts this residual risk (low impact for a
+  static portfolio with no authenticated actions).
+- **HSTS on GitHub Pages**: not configurable; GitHub serves HTTPS with
+  enforce-HTTPS enabled, and the meta CSP now includes
+  `upgrade-insecure-requests` as a partial mitigation.
+
+## Re-review triggers
+
+Re-run a review when any of the following change: new third-party scripts are
+added, forms or user input are introduced, the hosting platform changes, or a
+non-static rendering mode (SSR/actions) is adopted.

--- a/docs/security-review-2026-06-09.md
+++ b/docs/security-review-2026-06-09.md
@@ -30,9 +30,12 @@ The findings below were either fixed in the accompanying commit or accepted with
    keeps pinned SHAs updated.
 
 2. **Added HTTP security headers to `vercel.json`**: `Strict-Transport-Security`,
-   `X-Frame-Options: DENY`, `X-Content-Type-Options`, `Referrer-Policy`, and
-   `Permissions-Policy`. These apply to the Vercel mirror; see "accepted risks"
-   for the GitHub Pages caveat.
+   `X-Frame-Options: DENY`, `X-Content-Type-Options`, `Referrer-Policy`,
+   `Permissions-Policy`, and a full `Content-Security-Policy` header (including
+   `frame-ancestors 'none'`, which only works as a header). These apply to the
+   Vercel mirror; see "accepted risks" for the GitHub Pages caveat. The meta CSP
+   in `Layout.astro` remains as the protection for GitHub Pages, which cannot
+   set response headers.
 
 3. **Hardened the meta CSP** in `src/layouts/Layout.astro` with
    `object-src 'none'`, `base-uri 'self'`, `form-action 'self'`, and

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -10,7 +10,12 @@ const t = useTranslations(lang);
 ---
 
 <section class="hero">
-  <div class="container">
+  <div class="hero-aurora" aria-hidden="true">
+    <span class="aurora-blob aurora-1"></span>
+    <span class="aurora-blob aurora-2"></span>
+    <span class="aurora-blob aurora-3"></span>
+  </div>
+  <div class="container hero-content">
     <p class="hero-greeting">{t('hero.greeting')}</p>
     <h1 class="hero-name">{t('hero.name')}</h1>
     <p class="hero-tagline">{t('hero.tagline')}</p>
@@ -31,6 +36,76 @@ const t = useTranslations(lang);
     padding: var(--space-3xl) 0;
     display: flex;
     align-items: center;
+    position: relative;
+    overflow: hidden;
+  }
+
+  .hero-content {
+    position: relative;
+    z-index: 1;
+  }
+
+  .hero-aurora {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    overflow: hidden;
+  }
+
+  .aurora-blob {
+    position: absolute;
+    border-radius: 50%;
+    filter: blur(80px);
+    opacity: 0.22;
+    will-change: transform;
+  }
+
+  .aurora-1 {
+    width: 28rem;
+    height: 28rem;
+    top: -10rem;
+    left: -6rem;
+    background: var(--color-accent);
+    animation: aurora-drift 18s ease-in-out infinite alternate;
+  }
+
+  .aurora-2 {
+    width: 22rem;
+    height: 22rem;
+    top: -4rem;
+    right: -8rem;
+    background: var(--color-magic);
+    animation: aurora-drift 24s ease-in-out infinite alternate-reverse;
+  }
+
+  .aurora-3 {
+    width: 18rem;
+    height: 18rem;
+    bottom: -12rem;
+    left: 35%;
+    background: #14b8a6;
+    animation: aurora-drift 30s ease-in-out infinite alternate;
+  }
+
+  @keyframes aurora-drift {
+    from { transform: translate3d(0, 0, 0) scale(1); }
+    to { transform: translate3d(4rem, 2.5rem, 0) scale(1.15); }
+  }
+
+  :global(:root[data-theme="light"]) .aurora-blob {
+    opacity: 0.14;
+  }
+
+  @media (prefers-color-scheme: light) {
+    :global(:root:not([data-theme="dark"])) .aurora-blob {
+      opacity: 0.14;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .aurora-blob {
+      animation: none;
+    }
   }
 
   .hero-greeting {
@@ -45,6 +120,47 @@ const t = useTranslations(lang);
     font-weight: 700;
     line-height: 1.2;
     margin-bottom: var(--space-md);
+    background: linear-gradient(
+      110deg,
+      var(--color-text) 0%,
+      var(--color-text) 38%,
+      var(--color-accent) 48%,
+      var(--color-magic) 52%,
+      var(--color-text) 62%,
+      var(--color-text) 100%
+    );
+    background-size: 250% 100%;
+    background-position: 100% 0;
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    color: var(--color-text);
+    animation: name-shimmer 7s ease-in-out infinite;
+  }
+
+  @keyframes name-shimmer {
+    0%, 55% { background-position: 100% 0; }
+    85%, 100% { background-position: -100% 0; }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .hero-name {
+      animation: none;
+      background: none;
+      -webkit-text-fill-color: currentColor;
+    }
+  }
+
+  @media print {
+    .hero-name {
+      animation: none;
+      background: none;
+      -webkit-text-fill-color: currentColor;
+    }
+
+    .hero-aurora {
+      display: none;
+    }
   }
 
   .hero-tagline {

--- a/src/layouts/ArticleLayout.astro
+++ b/src/layouts/ArticleLayout.astro
@@ -212,7 +212,7 @@ const relatedArticles = scoredArticles
     left: 0;
     width: 100%;
     height: 3px;
-    background: var(--color-accent);
+    background: var(--gradient-magic);
     transform-origin: left;
     transform: scaleX(0);
     z-index: 200;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -38,7 +38,7 @@ const hreflangMap: Record<string, string> = { en: 'en', es: 'es', cat: 'ca' };
     <meta http-equiv="X-Content-Type-Options" content="nosniff" />
     <meta name="referrer" content="strict-origin-when-cross-origin" />
     <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=()" />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cloud.umami.is; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://cloud.umami.is https://api-gateway.umami.dev https://raw.githubusercontent.com" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cloud.umami.is; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://cloud.umami.is https://api-gateway.umami.dev https://raw.githubusercontent.com; object-src 'none'; base-uri 'self'; form-action 'self'; upgrade-insecure-requests" />
 
     <meta name="description" content={description} />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
@@ -291,7 +291,7 @@ const hreflangMap: Record<string, string> = { en: 'en', es: 'es', cat: 'ca' };
       }
       initMenuToggle();
 
-      // Theme toggle
+      // Theme toggle — with a circular sweep via the View Transitions API where supported
       let themeAbort: AbortController | null = null;
 
       function initThemeToggle() {
@@ -312,11 +312,126 @@ const hreflangMap: Record<string, string> = { en: 'en', es: 'es', cat: 'ca' };
             const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
             next = prefersDark ? 'light' : 'dark';
           }
-          document.documentElement.setAttribute('data-theme', next);
-          localStorage.setItem('theme', next);
+
+          const applyTheme = () => {
+            document.documentElement.setAttribute('data-theme', next);
+            localStorage.setItem('theme', next);
+          };
+
+          const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+          if (!document.startViewTransition || reduceMotion) {
+            applyTheme();
+            return;
+          }
+
+          // Sweep the new theme out from the toggle button
+          const rect = toggle.getBoundingClientRect();
+          const x = rect.left + rect.width / 2;
+          const y = rect.top + rect.height / 2;
+          const radius = Math.hypot(
+            Math.max(x, window.innerWidth - x),
+            Math.max(y, window.innerHeight - y)
+          );
+
+          document.documentElement.classList.add('theme-switching');
+          const transition = document.startViewTransition(applyTheme);
+          transition.ready.then(() => {
+            document.documentElement.animate(
+              { clipPath: [`circle(0px at ${x}px ${y}px)`, `circle(${radius}px at ${x}px ${y}px)`] },
+              { duration: 450, easing: 'ease-in-out', pseudoElement: '::view-transition-new(root)' }
+            );
+          }).catch(() => {});
+          transition.finished.finally(() => {
+            document.documentElement.classList.remove('theme-switching');
+          });
         }, { signal: themeAbort!.signal });
       }
       initThemeToggle();
+
+      // Scroll-reveal: cards and section headers drift in as they enter the viewport.
+      // Classes are only added here, so content stays visible without JS.
+      let revealObserver: IntersectionObserver | null = null;
+
+      function initReveal() {
+        if (!('IntersectionObserver' in window)) return;
+        if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+        document.documentElement.classList.add('js-reveal');
+        revealObserver?.disconnect();
+        revealObserver = new IntersectionObserver((entries) => {
+          for (const entry of entries) {
+            if (entry.isIntersecting) {
+              entry.target.classList.add('revealed');
+              revealObserver?.unobserve(entry.target);
+            }
+          }
+        }, { threshold: 0.1, rootMargin: '0px 0px -8% 0px' });
+
+        const targets = document.querySelectorAll('.grid > *, .related-grid > *, .link-card, .section-title, .section-description');
+        let index = 0;
+        targets.forEach((el) => {
+          if (el.classList.contains('revealed')) return;
+          (el as HTMLElement).style.setProperty('--reveal-delay', `${(index++ % 5) * 70}ms`);
+          el.classList.add('reveal');
+          revealObserver?.observe(el);
+        });
+      }
+      initReveal();
+
+      // Cursor spotlight: cards glow where the pointer is (document-level, survives swaps)
+      document.addEventListener('pointermove', (e) => {
+        const target = e.target as Element | null;
+        const card = target?.closest?.('.card, .link-card');
+        if (!(card instanceof HTMLElement)) return;
+        const rect = card.getBoundingClientRect();
+        card.style.setProperty('--glow-x', `${e.clientX - rect.left}px`);
+        card.style.setProperty('--glow-y', `${e.clientY - rect.top}px`);
+      }, { passive: true });
+
+      // Easter egg: type "magic" anywhere for a little sparkle shower ✨
+      const magicWord = 'magic';
+      let magicProgress = 0;
+
+      document.addEventListener('keydown', (e) => {
+        if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+        const key = e.key.length === 1 ? e.key.toLowerCase() : '';
+        magicProgress = key === magicWord[magicProgress] ? magicProgress + 1 : (key === magicWord[0] ? 1 : 0);
+        if (magicProgress === magicWord.length) {
+          magicProgress = 0;
+          castSparkles();
+        }
+      });
+
+      function castSparkles() {
+        if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+        const field = document.createElement('div');
+        field.className = 'sparkle-field';
+        field.setAttribute('aria-hidden', 'true');
+        const glyphs = ['✨', '⭐', '🌟', '💫'];
+        for (let i = 0; i < 36; i++) {
+          const sparkle = document.createElement('span');
+          sparkle.className = 'sparkle';
+          sparkle.textContent = glyphs[Math.floor(Math.random() * glyphs.length)];
+          sparkle.style.cssText = `
+            left: ${Math.random() * 100}%;
+            top: ${20 + Math.random() * 80}%;
+            font-size: ${0.6 + Math.random() * 1.4}rem;
+            animation-delay: ${Math.random() * 0.8}s;
+            --sparkle-duration: ${1 + Math.random() * 1.2}s;
+          `;
+          field.appendChild(sparkle);
+        }
+        document.body.appendChild(field);
+        setTimeout(() => field.remove(), 2600);
+      }
+
+      // A hint for fellow explorers of the console
+      // eslint-disable-next-line no-console
+      console.log(
+        '%c✨ Curious, are we? %c\n\nTry typing "magic" anywhere on the page…\nor the old classic: ↑ ↑ ↓ ↓ ← → ← → B A',
+        'font-size: 1.2em; font-weight: bold; color: #8b5cf6;',
+        'color: #3b82f6;'
+      );
 
       document.addEventListener('astro:after-swap', () => {
         const theme = localStorage.getItem('theme');
@@ -325,6 +440,7 @@ const hreflangMap: Record<string, string> = { en: 'en', es: 'es', cat: 'ca' };
         initMenuToggle();
         initLogoEasterEgg();
         initKonamiClose();
+        initReveal();
       });
     </script>
   </body>
@@ -381,11 +497,37 @@ const hreflangMap: Record<string, string> = { en: 'en', es: 'es', cat: 'ca' };
     color: var(--color-text-muted);
     font-weight: 500;
     transition: color 0.2s ease;
+    position: relative;
+  }
+
+  .nav-links a::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: -4px;
+    height: 2px;
+    border-radius: 1px;
+    background: var(--gradient-magic);
+    transform: scaleX(0);
+    transform-origin: left;
+    transition: transform 0.25s ease;
   }
 
   .nav-links a:hover,
   .nav-links a[aria-current="page"] {
     color: var(--color-text);
+  }
+
+  .nav-links a:hover::after,
+  .nav-links a[aria-current="page"]::after {
+    transform: scaleX(1);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .nav-links a::after {
+      transition: none;
+    }
   }
 
   .nav-actions {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -378,22 +378,40 @@ const hreflangMap: Record<string, string> = { en: 'en', es: 'es', cat: 'ca' };
       }
       initReveal();
 
-      // Cursor spotlight: cards glow where the pointer is (document-level, survives swaps)
-      document.addEventListener('pointermove', (e) => {
-        const target = e.target as Element | null;
-        const card = target?.closest?.('.card, .link-card');
-        if (!(card instanceof HTMLElement)) return;
-        const rect = card.getBoundingClientRect();
-        card.style.setProperty('--glow-x', `${e.clientX - rect.left}px`);
-        card.style.setProperty('--glow-y', `${e.clientY - rect.top}px`);
+      // Cursor spotlight: cards glow where the pointer is (document-level, survives swaps).
+      // The hovered card's rect is cached lazily and invalidated on scroll/resize so
+      // pointermove never forces a layout pass (rects are viewport-relative).
+      let spotlightCard: HTMLElement | null = null;
+      let spotlightRect: DOMRect | null = null;
+
+      document.addEventListener('pointerover', (e) => {
+        const card = (e.target as Element | null)?.closest?.('.card, .link-card');
+        const el = card instanceof HTMLElement ? card : null;
+        if (el !== spotlightCard) {
+          spotlightCard = el;
+          spotlightRect = null;
+        }
       }, { passive: true });
+
+      document.addEventListener('pointermove', (e) => {
+        if (!spotlightCard) return;
+        spotlightRect ??= spotlightCard.getBoundingClientRect();
+        spotlightCard.style.setProperty('--glow-x', `${e.clientX - spotlightRect.left}px`);
+        spotlightCard.style.setProperty('--glow-y', `${e.clientY - spotlightRect.top}px`);
+      }, { passive: true });
+
+      const invalidateSpotlightRect = () => { spotlightRect = null; };
+      document.addEventListener('scroll', invalidateSpotlightRect, { passive: true, capture: true });
+      window.addEventListener('resize', invalidateSpotlightRect, { passive: true });
 
       // Easter egg: type "magic" anywhere for a little sparkle shower ✨
       const magicWord = 'magic';
       let magicProgress = 0;
 
       document.addEventListener('keydown', (e) => {
-        if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+        if (e.ctrlKey || e.metaKey || e.altKey) return;
+        const target = e.target as HTMLElement | null;
+        if (target && (target.isContentEditable || ['INPUT', 'TEXTAREA', 'SELECT'].includes(target.tagName))) return;
         const key = e.key.length === 1 ? e.key.toLowerCase() : '';
         magicProgress = key === magicWord[magicProgress] ? magicProgress + 1 : (key === magicWord[0] ? 1 : 0);
         if (magicProgress === magicWord.length) {
@@ -436,6 +454,8 @@ const hreflangMap: Record<string, string> = { en: 'en', es: 'es', cat: 'ca' };
       document.addEventListener('astro:after-swap', () => {
         const theme = localStorage.getItem('theme');
         if (theme) document.documentElement.setAttribute('data-theme', theme);
+        spotlightCard = null;
+        spotlightRect = null;
         initThemeToggle();
         initMenuToggle();
         initLogoEasterEgg();

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -43,6 +43,22 @@ import '../styles/global.css';
     line-height: 1;
     margin-bottom: var(--space-md);
     color: var(--color-text-muted);
+    background: var(--gradient-magic);
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    animation: error-float 3s ease-in-out infinite;
+  }
+
+  @keyframes error-float {
+    0%, 100% { transform: translateY(0); }
+    50% { transform: translateY(-8px); }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .error-code {
+      animation: none;
+    }
   }
 
   .error-message {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -9,6 +9,9 @@
   --color-accent-solid: #2563eb;
   --color-accent-solid-hover: #1d4ed8;
   --color-border: #262626;
+  --color-magic: #8b5cf6;
+  --color-glow: rgba(59, 130, 246, 0.14);
+  --gradient-magic: linear-gradient(90deg, var(--color-accent), var(--color-magic));
 
   /* Health tier colours */
   --color-tier-gold: #ffd700;
@@ -49,6 +52,7 @@
     --color-accent-solid: #2563eb;
     --color-accent-solid-hover: #1d4ed8;
     --color-border: #e5e5e5;
+    --color-glow: rgba(37, 99, 235, 0.08);
   }
 }
 
@@ -63,6 +67,7 @@
   --color-accent-solid: #2563eb;
   --color-accent-solid-hover: #1d4ed8;
   --color-border: #e5e5e5;
+  --color-glow: rgba(37, 99, 235, 0.08);
 }
 
 /* Reset */
@@ -92,6 +97,17 @@ a {
 
 a:hover {
   color: var(--color-accent-hover);
+}
+
+::selection {
+  background: var(--color-accent-solid);
+  color: #fff;
+}
+
+:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+  border-radius: 0.25rem;
 }
 
 img {
@@ -127,11 +143,41 @@ img {
   border: 1px solid var(--color-border);
   border-radius: 0.75rem;
   padding: var(--space-lg);
-  transition: border-color 0.2s ease;
+  transition: border-color 0.2s ease, transform 0.25s ease, box-shadow 0.25s ease;
 }
 
 .card:hover {
   border-color: var(--color-accent);
+}
+
+/* Cursor spotlight: cards glow where the pointer is (--glow-x/y set by Layout script) */
+.card,
+.link-card {
+  position: relative;
+  overflow: hidden;
+}
+
+.card::before,
+.link-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(320px circle at var(--glow-x, 50%) var(--glow-y, 50%), var(--color-glow), transparent 70%);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.card:hover::before,
+.link-card:hover::before {
+  opacity: 1;
+}
+
+@media (hover: hover) and (prefers-reduced-motion: no-preference) {
+  .card:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.25);
+  }
 }
 
 /* Grid */
@@ -227,6 +273,65 @@ img {
 .link-card-content p {
   font-size: 0.875rem;
   color: var(--color-text-muted);
+}
+
+/* Scroll reveal (classes only applied by Layout script, so no-JS users see everything) */
+@media (prefers-reduced-motion: no-preference) {
+  .js-reveal .reveal {
+    opacity: 0;
+    transform: translateY(18px);
+    transition: opacity 0.55s ease, transform 0.55s cubic-bezier(0.22, 1, 0.36, 1);
+    transition-delay: var(--reveal-delay, 0s);
+  }
+
+  .js-reveal .reveal.revealed {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/* Theme toggle: circular sweep via the View Transitions API.
+   Scoped to .theme-switching so Astro's navigation transitions keep their defaults. */
+html.theme-switching::view-transition-old(root),
+html.theme-switching::view-transition-new(root) {
+  animation: none;
+  mix-blend-mode: normal;
+}
+
+html.theme-switching::view-transition-old(root) {
+  z-index: 1;
+}
+
+html.theme-switching::view-transition-new(root) {
+  z-index: 2;
+}
+
+/* Sparkles for the "magic" easter egg */
+.sparkle-field {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 9998;
+  overflow: hidden;
+}
+
+.sparkle {
+  position: absolute;
+  animation: sparkle-pop var(--sparkle-duration, 1.2s) ease-out forwards;
+}
+
+@keyframes sparkle-pop {
+  0% {
+    transform: translateY(0) scale(0) rotate(0deg);
+    opacity: 0;
+  }
+  20% {
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(-12vh) scale(1.4) rotate(40deg);
+    opacity: 0;
+  }
 }
 
 /* Print Stylesheet */

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -107,7 +107,6 @@ a:hover {
 :focus-visible {
   outline: 2px solid var(--color-accent);
   outline-offset: 2px;
-  border-radius: 0.25rem;
 }
 
 img {

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,32 @@
 {
   "framework": "astro",
   "buildCommand": "npm run build",
-  "outputDirectory": "dist"
+  "outputDirectory": "dist",
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=31536000; includeSubDomains"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=()"
+        }
+      ]
+    }
+  ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -25,6 +25,10 @@
         {
           "key": "Permissions-Policy",
           "value": "camera=(), microphone=(), geolocation=()"
+        },
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' https://cloud.umami.is; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https://cloud.umami.is https://api-gateway.umami.dev https://raw.githubusercontent.com; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests"
         }
       ]
     }


### PR DESCRIPTION
- Pin codeql.yml actions to commit SHAs (matching ci.yml convention)
- Add HSTS, X-Frame-Options, nosniff, Referrer-Policy and
  Permissions-Policy headers to vercel.json
- Extend meta CSP with object-src, base-uri, form-action and
  upgrade-insecure-requests (in Layout.astro, committed with UI work)
- Document the full review in docs/security-review-2026-06-09.md

https://claude.ai/code/session_014pGddFJp4bSKMmBLi4pxGS